### PR TITLE
Erweiterung CountedTripModel um Attribute

### DIFF
--- a/app/src/main/java/de/vdvcount/app/AppActivity.java
+++ b/app/src/main/java/de/vdvcount/app/AppActivity.java
@@ -70,6 +70,13 @@ public class AppActivity extends AppCompatActivity {
                     Secret.setSecretString(Secret.API_ENDPOINT, null);
                     Secret.setSecretString(Secret.API_USERNAME, null);
                     Secret.setSecretString(Secret.API_PASSWORD, null);
+
+                    Status.setInt(Status.CURRENT_STATION_ID, -1);
+                    Status.setString(Status.CURRENT_STATION_NAME, null);
+                    Status.setInt(Status.CURRENT_TRIP_ID, -1);
+                    Status.setInt(Status.CURRENT_START_STOP_SEQUENCE, -1);
+                    Status.getInt(Status.CURRENT_VEHICLE_ID, null);
+                    Status.setStringArray(Status.CURRENT_COUNTED_DOOR_IDS, new String[] {});
                 } catch (InvalidKeyException e) {
                     throw new RuntimeException(e);
                 }

--- a/app/src/main/java/de/vdvcount/app/AppActivity.java
+++ b/app/src/main/java/de/vdvcount/app/AppActivity.java
@@ -6,9 +6,13 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.widget.Toast;
 
+import java.security.InvalidKeyException;
+import java.util.UUID;
+
 import androidx.databinding.DataBindingUtil;
 import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
+import de.vdvcount.app.common.Secret;
 import de.vdvcount.app.common.Status;
 import de.vdvcount.app.databinding.ActivityAppBinding;
 
@@ -60,6 +64,15 @@ public class AppActivity extends AppCompatActivity {
                 this.actionBarTapCountToast.show();
             } else if (this.actionBarTapCount >= 10) {
                 Status.setString(Status.STATUS, Status.Values.INITIAL);
+
+                try {
+                    Secret.setSecretString(Secret.DEVICE_ID, null);
+                    Secret.setSecretString(Secret.API_ENDPOINT, null);
+                    Secret.setSecretString(Secret.API_USERNAME, null);
+                    Secret.setSecretString(Secret.API_PASSWORD, null);
+                } catch (InvalidKeyException e) {
+                    throw new RuntimeException(e);
+                }
 
                 this.finishAffinity();
             }

--- a/app/src/main/java/de/vdvcount/app/AppActivity.java
+++ b/app/src/main/java/de/vdvcount/app/AppActivity.java
@@ -66,16 +66,16 @@ public class AppActivity extends AppCompatActivity {
                 Status.setString(Status.STATUS, Status.Values.INITIAL);
 
                 try {
-                    Secret.setSecretString(Secret.DEVICE_ID, null);
-                    Secret.setSecretString(Secret.API_ENDPOINT, null);
-                    Secret.setSecretString(Secret.API_USERNAME, null);
-                    Secret.setSecretString(Secret.API_PASSWORD, null);
+                    Secret.setSecretString(Secret.DEVICE_ID, "");
+                    Secret.setSecretString(Secret.API_ENDPOINT, "");
+                    Secret.setSecretString(Secret.API_USERNAME, "");
+                    Secret.setSecretString(Secret.API_PASSWORD, "");
 
                     Status.setInt(Status.CURRENT_STATION_ID, -1);
                     Status.setString(Status.CURRENT_STATION_NAME, null);
                     Status.setInt(Status.CURRENT_TRIP_ID, -1);
                     Status.setInt(Status.CURRENT_START_STOP_SEQUENCE, -1);
-                    Status.getInt(Status.CURRENT_VEHICLE_ID, null);
+                    Status.setString(Status.CURRENT_VEHICLE_ID, null);
                     Status.setStringArray(Status.CURRENT_COUNTED_DOOR_IDS, new String[] {});
                 } catch (InvalidKeyException e) {
                     throw new RuntimeException(e);

--- a/app/src/main/java/de/vdvcount/app/common/Secret.java
+++ b/app/src/main/java/de/vdvcount/app/common/Secret.java
@@ -8,6 +8,7 @@ import de.vdvcount.app.security.Cipher;
 
 public class Secret extends KeyValueStore {
 
+   public final static String DEVICE_ID = "de.vdvcount.app.kvs.secret.DEVICE_ID";
    public final static String API_ENDPOINT = "de.vdvcount.app.kvs.secret.API_ENDPOINT";
    public final static String API_USERNAME = "de.vdvcount.app.kvs.secret.API_USERNAME";
    public final static String API_PASSWORD = "de.vdvcount.app.kvs.secret.API_PASSWORD";

--- a/app/src/main/java/de/vdvcount/app/model/CountedTrip.java
+++ b/app/src/main/java/de/vdvcount/app/model/CountedTrip.java
@@ -26,6 +26,7 @@ public class CountedTrip extends Trip implements ApiObjectMapper<CountedTripObje
         countedTrip.setDirection(trip.getDirection());
         countedTrip.setHeadsign(trip.getHeadsign());
         countedTrip.setInternationalId(trip.getInternationalId());
+        countedTrip.setOperationDay(trip.getOperationDay());
         countedTrip.setNextTripId(trip.getNextTripId());
 
         for (StopTime stopTime : trip.getStopTimes()) {

--- a/app/src/main/java/de/vdvcount/app/model/CountedTrip.java
+++ b/app/src/main/java/de/vdvcount/app/model/CountedTrip.java
@@ -77,6 +77,7 @@ public class CountedTrip extends Trip implements ApiObjectMapper<CountedTripObje
         apiObject.setDirection(this.getDirection());
         apiObject.setHeadsign(this.getHeadsign());
         apiObject.setInternationalId(this.getInternationalId());
+        apiObject.setOperationDay(this.getOperationDay());
         apiObject.setNextTripId(this.getNextTripId());
         apiObject.setVehicleId(this.getVehicleId());
 

--- a/app/src/main/java/de/vdvcount/app/model/CountedTrip.java
+++ b/app/src/main/java/de/vdvcount/app/model/CountedTrip.java
@@ -1,15 +1,18 @@
 package de.vdvcount.app.model;
 
+import java.security.InvalidKeyException;
 import java.util.ArrayList;
 import java.util.List;
 
 import de.vdvcount.app.common.ApiObjectMapper;
+import de.vdvcount.app.common.Secret;
 import de.vdvcount.app.remote.CountedStopTimeObject;
 import de.vdvcount.app.remote.CountedTripObject;
 import de.vdvcount.app.remote.PassengerCountingEventObject;
 
 public class CountedTrip extends Trip implements ApiObjectMapper<CountedTripObject> {
 
+    private String deviceId;
     private String vehicleId;
     private List<CountedStopTime> countedStopTimes;
     private List<PassengerCountingEvent> unmatchedPassengerCountingEvents;
@@ -46,6 +49,14 @@ public class CountedTrip extends Trip implements ApiObjectMapper<CountedTripObje
         throw new RuntimeException("Method setStopTimes not available for CountedTrip object!");
     }
 
+    public String getDeviceId() {
+        return this.deviceId;
+    }
+
+    public void setDeviceId(String deviceId) {
+        this.deviceId = deviceId;
+    }
+
     public String getVehicleId() {
         return this.vehicleId;
     }
@@ -72,6 +83,15 @@ public class CountedTrip extends Trip implements ApiObjectMapper<CountedTripObje
 
     @Override
     public CountedTripObject mapApiObject() {
+        String deviceId;
+        try {
+            deviceId = Secret.getSecretString(Secret.DEVICE_ID, null);
+        } catch (InvalidKeyException ex) {
+            throw new RuntimeException(ex);
+        } catch (IllegalAccessException ex) {
+            throw new RuntimeException(ex);
+        }
+
         CountedTripObject apiObject = new CountedTripObject();
         apiObject.setTripId(this.getTripId());
         apiObject.setLine(this.getLine().mapApiObject());
@@ -80,6 +100,8 @@ public class CountedTrip extends Trip implements ApiObjectMapper<CountedTripObje
         apiObject.setInternationalId(this.getInternationalId());
         apiObject.setOperationDay(this.getOperationDay());
         apiObject.setNextTripId(this.getNextTripId());
+        apiObject.setDeviceId(this.getDeviceId());
+        apiObject.setDeviceId(deviceId);
         apiObject.setVehicleId(this.getVehicleId());
 
         List<CountedStopTimeObject> countedStopTimes = new ArrayList<>();

--- a/app/src/main/java/de/vdvcount/app/model/Trip.java
+++ b/app/src/main/java/de/vdvcount/app/model/Trip.java
@@ -9,6 +9,7 @@ public class Trip {
     private int direction;
     private String headsign;
     private String internationalId;
+    private int operationDay;
     private int nextTripId;
     private List<StopTime> stopTimes;
 
@@ -50,6 +51,14 @@ public class Trip {
 
     public void setInternationalId(String internationalId) {
         this.internationalId = internationalId;
+    }
+
+    public int getOperationDay() {
+        return this.operationDay;
+    }
+
+    public void setOperationDay(int operationDay) {
+        this.operationDay = operationDay;
     }
 
     public int getNextTripId() {

--- a/app/src/main/java/de/vdvcount/app/remote/CountedTripObject.java
+++ b/app/src/main/java/de/vdvcount/app/remote/CountedTripObject.java
@@ -11,6 +11,8 @@ import de.vdvcount.app.model.PassengerCountingEvent;
 
 public class CountedTripObject extends TripObject {
 
+    @SerializedName("device_id")
+    private String deviceId;
     @SerializedName("vehicle_id")
     private String vehicleId;
     @SerializedName("counted_stop_times")
@@ -31,6 +33,14 @@ public class CountedTripObject extends TripObject {
     @Override
     public void setStopTimes(List<StopTimeObject> stopTimes) {
         throw new RuntimeException("Method setStopTimes not available for CountedTripObject object!");
+    }
+
+    public String getDeviceId() {
+        return this.deviceId;
+    }
+
+    public void setDeviceId(String deviceId) {
+        this.deviceId = deviceId;
     }
 
     public String getVehicleId() {
@@ -68,6 +78,7 @@ public class CountedTripObject extends TripObject {
         domainModel.setInternationalId(this.getInternationalId());
         domainModel.setOperationDay(this.getOperationDay());
         domainModel.setNextTripId(this.getNextTripId());
+        domainModel.setDeviceId(this.getDeviceId());
         domainModel.setVehicleId(this.getVehicleId());
 
         List<CountedStopTime> countedStopTimes = new ArrayList<>();

--- a/app/src/main/java/de/vdvcount/app/remote/CountedTripObject.java
+++ b/app/src/main/java/de/vdvcount/app/remote/CountedTripObject.java
@@ -66,6 +66,7 @@ public class CountedTripObject extends TripObject {
         domainModel.setDirection(this.getDirection());
         domainModel.setHeadsign(this.getHeadsign());
         domainModel.setInternationalId(this.getInternationalId());
+        domainModel.setOperationDay(this.getOperationDay());
         domainModel.setNextTripId(this.getNextTripId());
         domainModel.setVehicleId(this.getVehicleId());
 

--- a/app/src/main/java/de/vdvcount/app/remote/TripObject.java
+++ b/app/src/main/java/de/vdvcount/app/remote/TripObject.java
@@ -21,6 +21,8 @@ class TripObject implements DomainModelMapper<Trip> {
    private String headsign;
    @SerializedName("international_id")
    private String internationalId;
+   @SerializedName("operation_day")
+   private int operationDay;
    @SerializedName("next_trip_id")
    private int nextTripId;
    @SerializedName("stop_times")
@@ -66,6 +68,14 @@ class TripObject implements DomainModelMapper<Trip> {
       this.internationalId = internationalId;
    }
 
+   public int getOperationDay() {
+      return this.operationDay;
+   }
+
+   public void setOperationDay(int operationDay) {
+      this.operationDay = operationDay;
+   }
+
    public int getNextTripId() {
       return this.nextTripId;
    }
@@ -91,6 +101,7 @@ class TripObject implements DomainModelMapper<Trip> {
       domainModel.setDirection(this.getDirection());
       domainModel.setHeadsign(this.getHeadsign());
       domainModel.setInternationalId(this.getInternationalId());
+      domainModel.setOperationDay(this.getOperationDay());
       domainModel.setNextTripId(this.getNextTripId());
 
       List<StopTime> stopTimes = new ArrayList<>();

--- a/app/src/main/java/de/vdvcount/app/ui/setup/SetupViewModel.java
+++ b/app/src/main/java/de/vdvcount/app/ui/setup/SetupViewModel.java
@@ -2,6 +2,7 @@ package de.vdvcount.app.ui.setup;
 
 import java.net.URI;
 import java.security.InvalidKeyException;
+import java.util.UUID;
 
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.ViewModel;
@@ -52,6 +53,7 @@ public class SetupViewModel extends ViewModel {
                 String apiEndpoint = sanitizedUri.toString();
 
                 try {
+                    Secret.setSecretString(Secret.DEVICE_ID, UUID.randomUUID().toString());
                     Secret.setSecretString(Secret.API_ENDPOINT, apiEndpoint);
                     Secret.setSecretString(Secret.API_USERNAME, userCredentials[0]);
                     Secret.setSecretString(Secret.API_PASSWORD, userCredentials[1]);


### PR DESCRIPTION
Das CountedTrip-Objekt wurde um die Attribute `device_id` und `operation_day` erweitert. Während `operation_day` aus der API stammt und sozusagen nur zur Weiterverarbeitung "mitgeschleift" wird, wird die Geräte-ID beim Setup als UUID vergeben und dient später der Unterscheidung der Herkunft verschiedener Datensätze.