### PR TITLE
Finale Einrichtung CI/CD-Pipeline

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.android.application)
+
     id 'androidx.navigation.safeargs'
     id 'com.gladed.androidgitversion' version '0.4.14'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,10 +3,20 @@ plugins {
 
     id 'androidx.navigation.safeargs'
     id 'com.gladed.androidgitversion' version '0.4.14'
+    id 'com.jaredsburrows.license' version '0.9.8'
 }
 
 androidGitVersion {
     format '%tag%%.devcount%%+commit%'
+}
+
+licenseReport {
+    generateCsvReport = false
+    generateHtmlReport = false
+    generateJsonReport = false
+    generateTextReport = true
+
+    showVersions = true
 }
 
 android {

--- a/licenses/licenses.txt
+++ b/licenses/licenses.txt
@@ -1,0 +1,460 @@
+Notice for packages
+
+
+Activity (1.9.3) - The Apache Software License, Version 2.0
+Provides the base Activity subclass and the relevant hooks to build a composable structure on top.
+https://developer.android.com/jetpack/androidx/releases/activity#1.9.3
+
+Activity Kotlin Extensions (1.9.3) - The Apache Software License, Version 2.0
+Kotlin extensions for 'activity' artifact
+https://developer.android.com/jetpack/androidx/releases/activity#1.9.3
+
+Android App Startup Runtime (1.1.1) - The Apache Software License, Version 2.0
+Android App Startup Runtime
+https://developer.android.com/jetpack/androidx/releases/startup#1.1.1
+
+Android Arch-Common (2.2.0) - The Apache Software License, Version 2.0
+Android Arch-Common
+https://developer.android.com/jetpack/androidx/releases/arch-core#2.2.0
+
+Android Arch-Runtime (2.2.0) - The Apache Software License, Version 2.0
+Android Arch-Runtime
+https://developer.android.com/jetpack/androidx/releases/arch-core#2.2.0
+
+Android Emoji2 Compat (1.3.0) - The Apache Software License, Version 2.0
+Core library to enable emoji compatibility in Kitkat and newer devices to avoid the empty emoji characters.
+https://developer.android.com/jetpack/androidx/releases/emoji2#1.3.0
+
+Android Emoji2 Compat view helpers (1.3.0) - The Apache Software License, Version 2.0
+View helpers for Emoji2
+https://developer.android.com/jetpack/androidx/releases/emoji2#1.3.0
+
+Android Lifecycle Runtime (2.6.1) - The Apache Software License, Version 2.0
+Android Lifecycle Runtime
+https://developer.android.com/jetpack/androidx/releases/lifecycle#2.6.1
+
+Android Lifecycle-Common (2.6.1) - The Apache Software License, Version 2.0
+Android Lifecycle-Common
+https://developer.android.com/jetpack/androidx/releases/lifecycle#2.6.1
+
+Android Resource Inspection - Annotations (1.0.1) - The Apache Software License, Version 2.0
+Annotation processors for Android resource and layout inspection
+https://developer.android.com/jetpack/androidx/releases/resourceinspection#1.0.1
+
+Android Support AnimatedVectorDrawable (1.1.0) - The Apache Software License, Version 2.0
+Android Support AnimatedVectorDrawable
+https://developer.android.com/jetpack/androidx
+
+Android Support CardView v7 (1.0.0) - The Apache Software License, Version 2.0
+Android Support CardView v7
+http://developer.android.com/tools/extras/support-library.html
+
+Android Support DynamicAnimation (1.0.0) - The Apache Software License, Version 2.0
+Physics-based animation in support library, where the animations are driven by physics force. You can use this Animation library to create smooth and realistic animations.
+http://developer.android.com/tools/extras/support-library.html
+
+Android Support ExifInterface (1.3.2) - The Apache Software License, Version 2.0
+Android Support ExifInterface
+https://developer.android.com/jetpack/androidx/releases/exifinterface#1.3.2
+
+Android Support Library Annotations (1.2.0) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs.
+https://developer.android.com/jetpack/androidx/releases/annotation#1.2.0
+
+Android Support Library Async Layout Inflater (1.0.0) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
+http://developer.android.com/tools/extras/support-library.html
+
+Android Support Library collections (1.0.0) - The Apache Software License, Version 2.0
+Standalone efficient collections.
+http://developer.android.com/tools/extras/support-library.html
+
+Android Support Library Coordinator Layout (1.1.0) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
+https://developer.android.com/jetpack/androidx
+
+Android Support Library core UI (1.0.0) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
+http://developer.android.com/tools/extras/support-library.html
+
+Android Support Library core utils (1.0.0) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
+http://developer.android.com/tools/extras/support-library.html
+
+Android Support Library Cursor Adapter (1.0.0) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
+http://developer.android.com/tools/extras/support-library.html
+
+Android Support Library Custom View (1.1.0) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
+https://developer.android.com/jetpack/androidx
+
+Android Support Library Custom View (1.0.0) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
+http://developer.android.com/tools/extras/support-library.html
+
+Android Support Library Document File (1.0.0) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
+http://developer.android.com/tools/extras/support-library.html
+
+Android Support Library Drawer Layout (1.1.1) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
+https://developer.android.com/jetpack/androidx
+
+Android Support Library fragment (1.6.2) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
+https://developer.android.com/jetpack/androidx/releases/fragment#1.6.2
+
+Android Support Library Interpolators (1.0.0) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
+http://developer.android.com/tools/extras/support-library.html
+
+Android Support Library loader (1.0.0) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
+http://developer.android.com/tools/extras/support-library.html
+
+Android Support Library Local Broadcast Manager (1.0.0) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
+http://developer.android.com/tools/extras/support-library.html
+
+Android Support Library media compat (1.0.0) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
+http://developer.android.com/tools/extras/support-library.html
+
+Android Support Library Print (1.0.0) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
+http://developer.android.com/tools/extras/support-library.html
+
+Android Support Library Sliding Pane Layout (1.2.0) - The Apache Software License, Version 2.0
+SlidingPaneLayout offers a responsive, two pane layout that automatically switches between overlapping panes on smaller devices to a side by side view on larger devices.
+https://developer.android.com/jetpack/androidx/releases/slidingpanelayout#1.2.0
+
+Android Support Library v4 (1.0.0) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
+http://developer.android.com/tools/extras/support-library.html
+
+Android Support Library View Pager (1.0.0) - The Apache Software License, Version 2.0
+The Support Library is a static library that you can add to your Android application in order to use APIs that are either not available for older platform versions or utility APIs that aren't a part of the framework APIs. Compatible on devices running API 14 or later.
+http://developer.android.com/tools/extras/support-library.html
+
+Android Support RecyclerView v7 (1.1.0) - The Apache Software License, Version 2.0
+Android Support RecyclerView v7
+https://developer.android.com/jetpack/androidx
+
+Android Support VectorDrawable (1.1.0) - The Apache Software License, Version 2.0
+Android Support VectorDrawable
+https://developer.android.com/jetpack/androidx
+
+Android Tracing (1.0.0) - The Apache Software License, Version 2.0
+Android Tracing
+https://developer.android.com/jetpack/androidx/releases/tracing#1.0.0
+
+Android-Permissions (3.8)
+
+AndroidX Futures (1.1.0) - The Apache Software License, Version 2.0
+Androidx implementation of Guava's ListenableFuture
+https://developer.android.com/topic/libraries/architecture/index.html
+
+AndroidX Widget ViewPager2 (1.0.0) - The Apache Software License, Version 2.0
+AndroidX Widget ViewPager2
+https://developer.android.com/jetpack/androidx
+
+androidx.databinding.databinding-common (8.7.2) - The Apache Software License, Version 2.0
+Shared library between Data Binding runtime lib and compiler
+http://tools.android.com/
+
+Annotation (1.8.1) - The Apache Software License, Version 2.0
+Provides source annotations for tooling and readability.
+https://developer.android.com/jetpack/androidx/releases/annotation#1.8.1
+
+AppCompat (1.7.0) - The Apache Software License, Version 2.0
+Provides backwards-compatible implementations of UI-related Android SDK functionality, including dark mode and Material theming.
+https://developer.android.com/jetpack/androidx/releases/appcompat#1.7.0
+
+AppCompat Resources (1.7.0) - The Apache Software License, Version 2.0
+Provides backward-compatible implementations of resource-related Android SDKfunctionality, including color state list theming.
+https://developer.android.com/jetpack/androidx/releases/appcompat#1.7.0
+
+AutoValue Annotations (1.6.3) - Apache 2.0
+Immutable value-type code generation for Java 1.6+.
+
+barcode-scanning (17.1.0) - ML Kit Terms of Service
+
+barcode-scanning-common (17.0.0) - ML Kit Terms of Service
+
+collections (1.4.2) - The Apache Software License, Version 2.0
+Standalone efficient collections.
+https://developer.android.com/jetpack/androidx/releases/collection#1.4.2
+
+Collections Kotlin Extensions (1.4.2) - The Apache Software License, Version 2.0
+Kotlin extensions for 'collection' artifact
+https://developer.android.com/jetpack/androidx/releases/collection#1.4.2
+
+common (18.7.0) - ML Kit Terms of Service
+
+ConstraintLayout (2.2.0) - The Apache Software License, Version 2.0
+This library offers a flexible and adaptable way to position and animate widgets
+https://developer.android.com/jetpack/androidx/releases/constraintlayout#2.2.0
+
+ConstraintLayout Core (1.1.0) - The Apache Software License, Version 2.0
+This library contains engines and algorithms for constraint based layout and complex animations (it is used by the ConstraintLayout library)
+https://developer.android.com/jetpack/androidx/releases/constraintlayout#1.1.0
+
+Converter: Gson (2.11.0) - The Apache Software License, Version 2.0
+A Retrofit Converter which uses Gson for serialization.
+https://github.com/square/retrofit
+
+Core (1.13.0) - The Apache Software License, Version 2.0
+Provides backward-compatible implementations of Android platform APIs and features.
+https://developer.android.com/jetpack/androidx/releases/core#1.13.0
+
+Core Kotlin Extensions (1.13.0) - The Apache Software License, Version 2.0
+Kotlin extensions for 'core' artifact
+https://developer.android.com/jetpack/androidx/releases/core#1.13.0
+
+databinding-adapters (8.7.2) - The Apache Software License, Version 2.0
+
+databinding-runtime (8.7.2) - The Apache Software License, Version 2.0
+
+error-prone annotations (2.15.0) - Apache 2.0
+
+Experimental annotation (1.4.1) - The Apache Software License, Version 2.0
+Java annotation for use on unstable Android API surfaces. When used in conjunction with the Experimental annotation lint checks, this annotation provides functional parity with Kotlin's Experimental annotation.
+https://developer.android.com/jetpack/androidx/releases/annotation#1.4.1
+
+firebase-annotations (16.0.0) - The Apache Software License, Version 2.0
+
+firebase-components (16.1.0) - The Apache Software License, Version 2.0
+
+firebase-encoders (16.1.0) - The Apache Software License, Version 2.0
+
+firebase-encoders-json (17.1.0) - The Apache Software License, Version 2.0
+
+Fragment Kotlin Extensions (1.6.2) - The Apache Software License, Version 2.0
+Kotlin extensions for 'fragment' artifact
+https://developer.android.com/jetpack/androidx/releases/fragment#1.6.2
+
+Gson (2.10.1) - Apache-2.0
+
+      Guava ListenableFuture only (1.0) - The Apache Software License, Version 2.0
+      Contains Guava's com.google.common.util.concurrent.ListenableFuture class,
+without any of its other classes -- but is also available in a second
+"version" that omits the class to avoid conflicts with the copy in Guava
+itself. The idea is:
+
+- If users want only ListenableFuture, they depend on listenablefuture-1.0.
+
+- If users want all of Guava, they depend on guava, which, as of Guava
+27.0, depends on
+listenablefuture-9999.0-empty-to-avoid-conflict-with-guava. The 9999.0-...
+version number is enough for some build systems (notably, Gradle) to select
+that empty artifact over the "real" listenablefuture-1.0 -- avoiding a
+conflict with the copy of ListenableFuture in guava itself. If users are
+using an older version of Guava or a build system other than Gradle, they
+may see class conflicts. If so, they can solve them by manually excluding
+the listenablefuture artifact or manually forcing their build systems to
+use 9999.0-....
+
+image (1.0.0-beta1) - Android Software Development Kit License
+
+javax.inject (1) - The Apache Software License, Version 2.0
+The javax.inject API
+http://code.google.com/p/atinject/
+
+JetBrains Java Annotations (23.0.0) - The Apache Software License, Version 2.0
+A set of annotations used for code inspection support and code documentation.
+https://github.com/JetBrains/java-annotations
+
+Jetpack Camera Core Library (1.2.0-alpha04) - The Apache Software License, Version 2.0,BSD License
+Core components for the Jetpack Camera Library, a library providing a consistent and reliable camera foundation that enables great camera driven experiences across all of Android.
+https://developer.android.com/jetpack/androidx/releases/camera#1.2.0-alpha04
+
+Jetpack Camera Library Camera2 Implementation/Extensions (1.2.0-alpha04) - The Apache Software License, Version 2.0
+Camera2 implementation and extensions for the Jetpack Camera Library, a library providing a consistent and reliable camera foundation that enables great camera driven experiences across all of Android.
+https://developer.android.com/jetpack/androidx/releases/camera#1.2.0-alpha04
+
+Jetpack Camera Lifecycle Library (1.2.0-alpha04) - The Apache Software License, Version 2.0
+Lifecycle components for the Jetpack Camera Library, a library providing a consistent and reliable camera foundation that enables great camera driven experiences across all of Android.
+https://developer.android.com/jetpack/androidx/releases/camera#1.2.0-alpha04
+
+Jetpack Camera View Library (1.2.0-alpha04) - The Apache Software License, Version 2.0
+UI tools for the Jetpack Camera Library, a library providing a consistent and reliable camera foundation that enables great camera driven experiences across all of Android.
+https://developer.android.com/jetpack/androidx/releases/camera#1.2.0-alpha04
+
+Jetpack WindowManager Library (1.0.0) - The Apache Software License, Version 2.0
+WindowManager Jetpack library. Currently only provides additional functionality on foldable devices.
+https://developer.android.com/jetpack/androidx/releases/window#1.0.0
+
+Kotlin Stdlib (1.9.22) - The Apache License, Version 2.0
+Kotlin Standard Library
+https://kotlinlang.org/
+
+Kotlin Stdlib Common (1.8.10) - The Apache License, Version 2.0
+Kotlin Common Standard Library
+https://kotlinlang.org/
+
+Kotlin Stdlib Jdk7 (1.8.22) - The Apache License, Version 2.0
+Kotlin Standard Library JDK 7 extension
+https://kotlinlang.org/
+
+Kotlin Stdlib Jdk8 (1.8.22) - The Apache License, Version 2.0
+Kotlin Standard Library JDK 8 extension
+https://kotlinlang.org/
+
+kotlinx-coroutines-android (1.7.3) - The Apache Software License, Version 2.0
+Coroutines support libraries for Kotlin
+https://github.com/Kotlin/kotlinx.coroutines
+
+kotlinx-coroutines-core (1.7.3) - The Apache Software License, Version 2.0
+Coroutines support libraries for Kotlin
+https://github.com/Kotlin/kotlinx.coroutines
+
+kotlinx-serialization-core (1.6.3) - The Apache Software License, Version 2.0
+Kotlin multiplatform serialization runtime library
+https://github.com/Kotlin/kotlinx.serialization
+
+Lifecycle Kotlin Extensions (2.8.7) - The Apache Software License, Version 2.0
+Kotlin extensions for 'lifecycle' artifact
+https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.7
+
+Lifecycle LiveData (2.8.7) - The Apache Software License, Version 2.0
+Android Lifecycle LiveData
+https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.7
+
+Lifecycle LiveData Core (2.8.7) - The Apache Software License, Version 2.0
+Android Lifecycle LiveData Core
+https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.7
+
+Lifecycle Process (2.8.7) - The Apache Software License, Version 2.0
+Android Lifecycle Process
+https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.7
+
+Lifecycle Runtime (2.8.7) - The Apache Software License, Version 2.0
+Android Lifecycle Runtime
+https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.7
+
+Lifecycle Runtime (2.8.7) - The Apache Software License, Version 2.0
+Android Lifecycle Runtime
+https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.7
+
+Lifecycle ViewModel (2.8.7) - The Apache Software License, Version 2.0
+Android Lifecycle ViewModel
+https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.7
+
+Lifecycle ViewModel (2.8.7) - The Apache Software License, Version 2.0
+Android Lifecycle ViewModel
+https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.7
+
+Lifecycle ViewModel (2.8.7) - The Apache Software License, Version 2.0
+Android Lifecycle ViewModel
+https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.7
+
+Lifecycle ViewModel Kotlin Extensions (2.8.7) - The Apache Software License, Version 2.0
+Kotlin extensions for 'viewmodel' artifact
+https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.7
+
+Lifecycle ViewModel with SavedState (2.8.7) - The Apache Software License, Version 2.0
+Android Lifecycle ViewModel
+https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.7
+
+Lifecycle-Common (2.8.7) - The Apache Software License, Version 2.0
+Android Lifecycle-Common
+https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.7
+
+LiveData Core Kotlin Extensions (2.8.7) - The Apache Software License, Version 2.0
+Kotlin extensions for 'livedata-core' artifact
+https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.7
+
+LiveData Kotlin Extensions (2.8.7) - The Apache Software License, Version 2.0
+Kotlin extensions for 'livedata' artifact
+https://developer.android.com/jetpack/androidx/releases/lifecycle#2.8.7
+
+Material Components for Android (1.12.0) - The Apache Software License, Version 2.0
+Material Components for Android is a static library that you can add to your Android application in order to use APIs that provide implementations of the Material Design specification. Compatible on devices running API 14 or later.
+https://github.com/material-components/material-components-android
+
+Navigation Common (2.8.4) - The Apache Software License, Version 2.0
+Android Navigation-Common
+https://developer.android.com/jetpack/androidx/releases/navigation#2.8.4
+
+Navigation Common Kotlin Extensions (2.8.4) - The Apache Software License, Version 2.0
+Android Navigation-Common-Ktx
+https://developer.android.com/jetpack/androidx/releases/navigation#2.8.4
+
+Navigation Fragment (2.8.4) - The Apache Software License, Version 2.0
+Android Navigation-Fragment
+https://developer.android.com/jetpack/androidx/releases/navigation#2.8.4
+
+Navigation Fragment Kotlin Extensions (2.8.4) - The Apache Software License, Version 2.0
+Android Navigation-Fragment-Ktx
+https://developer.android.com/jetpack/androidx/releases/navigation#2.8.4
+
+Navigation Runtime (2.8.4) - The Apache Software License, Version 2.0
+Android Navigation-Runtime
+https://developer.android.com/jetpack/androidx/releases/navigation#2.8.4
+
+Navigation Runtime Kotlin Extensions (2.8.4) - The Apache Software License, Version 2.0
+Android Navigation-Runtime-Ktx
+https://developer.android.com/jetpack/androidx/releases/navigation#2.8.4
+
+Navigation UI (2.8.4) - The Apache Software License, Version 2.0
+Android Navigation-UI
+https://developer.android.com/jetpack/androidx/releases/navigation#2.8.4
+
+Navigation UI Kotlin Extensions (2.8.4) - The Apache Software License, Version 2.0
+Android Navigation-UI-Ktx
+https://developer.android.com/jetpack/androidx/releases/navigation#2.8.4
+
+OkHttp (3.14.9) - Apache 2.0
+
+Okio (1.17.2) - Apache 2.0
+
+play-services-base (18.1.0) - Android Software Development Kit License
+
+play-services-basement (18.1.0) - Android Software Development Kit License
+
+play-services-location (21.0.1) - Android Software Development Kit License
+
+play-services-mlkit-barcode-scanning (18.2.0) - ML Kit Terms of Service
+
+play-services-tasks (18.0.2) - Android Software Development Kit License
+
+Profile Installer (1.4.0) - The Apache Software License, Version 2.0
+Allows libraries to prepopulate ahead of time compilation traces to be read by ART
+https://developer.android.com/jetpack/androidx/releases/profileinstaller#1.4.0
+
+Retrofit (2.11.0) - The Apache Software License, Version 2.0
+A type-safe HTTP client for Android and Java.
+https://github.com/square/retrofit
+
+Saved State (1.2.1) - The Apache Software License, Version 2.0
+Android Lifecycle Saved State
+https://developer.android.com/jetpack/androidx/releases/savedstate#1.2.1
+
+SavedState Kotlin Extensions (1.2.1) - The Apache Software License, Version 2.0
+Kotlin extensions for 'savedstate' artifact
+https://developer.android.com/jetpack/androidx/releases/savedstate#1.2.1
+
+TimelineView (1.1.5) - The Apache Software License, Version 2.0
+Android Timeline View Library (Using RecyclerView) is simple implementation used to display view like Tracking of shipment/order, steppers etc.
+https://github.com/vipulasri/Timeline-View
+
+Transition (1.5.0) - The Apache Software License, Version 2.0
+Android Transition Support Library
+https://developer.android.com/jetpack/androidx/releases/transition#1.5.0
+
+transport-api (2.2.1) - The Apache Software License, Version 2.0
+
+transport-backend-cct (2.3.3) - The Apache Software License, Version 2.0
+
+transport-runtime (2.2.6) - The Apache Software License, Version 2.0
+
+VersionedParcelable (1.1.1) - The Apache Software License, Version 2.0
+Provides a stable but relatively compact binary serialization format that can be passed across processes or persisted safely.
+http://developer.android.com/tools/extras/support-library.html
+
+viewbinding (8.7.2) - The Apache Software License, Version 2.0
+
+vision-common (17.3.0) - ML Kit Terms of Service
+
+vision-interfaces (16.2.0) - ML Kit Terms of Service


### PR DESCRIPTION
Die CI/CD-Pipeline wurde um die automatische Erzeugung von Lizenztexten verwendeter OSS-Lizenzen erweitert.