### PR TITLE
Bugfix: Fahrt-Abschluss nur bei aktiver Netzwerkverbindung

### DIFF
--- a/app/src/main/res/layout/fragment_trip_details.xml
+++ b/app/src/main/res/layout/fragment_trip_details.xml
@@ -3,45 +3,113 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <androidx.core.widget.NestedScrollView
+    <data>
+
+        <import type="de.vdvcount.app.ui.tripdetails.TripDetailsFragment" />
+
+        <import type="de.vdvcount.app.ui.tripdetails.TripDetailsViewModel" />
+
+        <import type="android.view.View" />
+
+        <variable
+            type="TripDetailsViewModel"
+            name="viewModel" />
+
+    </data>
+
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <LinearLayout
+        <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="match_parent"
+            android:visibility="@{viewModel.state == TripDetailsFragment.State.READY || viewModel.state == TripDetailsFragment.State.LOADING ? View.VISIBLE : View.GONE}">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
 
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/lstCountedStopTimes"
+                <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"  />
+                    android:visibility="@{viewModel.state == TripDetailsFragment.State.READY ? View.VISIBLE : View.GONE}">
 
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/btnQuit"
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/lstCountedStopTimes"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"  />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btnQuit"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/app_medium_spacing"
+                        android:layout_marginStart="@dimen/app_default_spacing"
+                        android:layout_marginEnd="@dimen/app_default_spacing"
+                        android:layout_marginBottom="8dp"
+                        android:text="@string/trip_details_quit"
+                        app:layout_constraintTop_toBottomOf="@id/lstCountedStopTimes"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintBottom_toBottomOf="parent" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <RelativeLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/app_medium_spacing"
-                    android:layout_marginStart="@dimen/app_default_spacing"
-                    android:layout_marginEnd="@dimen/app_default_spacing"
-                    android:layout_marginBottom="8dp"
-                    android:text="@string/trip_details_quit"
-                    app:layout_constraintTop_toBottomOf="@id/lstCountedStopTimes"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent" />
+                    android:visibility="@{viewModel.state == TripDetailsFragment.State.LOADING ? View.VISIBLE : View.GONE}">
 
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                    <ProgressBar
+                        android:layout_width="56dp"
+                        android:layout_height="56dp"
+                        android:layout_marginTop="160dp"
+                        android:layout_centerInParent="true"
+                        style="?android:attr/progressBarStyleLarge" />
 
-        </LinearLayout>
+                </RelativeLayout>
 
-    </androidx.core.widget.NestedScrollView>
+            </LinearLayout>
+
+        </androidx.core.widget.NestedScrollView>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/permission"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="@dimen/app_default_spacing"
+            android:visibility="@{viewModel.state == TripDetailsFragment.State.ERROR ? View.VISIBLE : View.GONE}"
+            tools:context=".ui.tripdetails.TripDetailsFragment">
+
+            <TextView
+                android:id="@+id/lblErrorMessage"
+                android:layout_width="320dp"
+                android:layout_height="wrap_content"
+                android:text="@string/str_network_load_error"
+                android:textAlignment="center"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                app:layout_constraintBottom_toTopOf="@id/btnRetry"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnRetry"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/str_retry"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </FrameLayout>
 
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,10 +40,12 @@
     <string name="app_name">VdvCountApp</string>
     <string name="app_reset_counter">Noch %dx zum Zurücksetzen.</string>
     <string name="str_continue">Weiter</string>
+    <string name="str_retry">Erneut versuchen</string>
     <string name="str_door">Tür %s</string>
     <string name="str_slash">/</string>
     <string name="str_minus">-</string>
     <string name="str_plus">+</string>
+    <string name="str_network_load_error">Während der Anfrage ist ein Fehler aufgetreten. Bitte prüfen Sie Ihre Netzwerkverbindung und versuchen Sie es erneut.</string>
 
     <string name="str_format_time">HH:mm</string>
 </resources>


### PR DESCRIPTION
Die App wurde dahingehend angepasst, dass der Fahrtabschluss nur bei aktiver Netzwerkverbindung funktioniert. Ist keine Netzwerkverbindung aktiv oder kommt es während der Anfrage an die API zu einem Problem, wird eine Fehlermeldung angezeigt und der User hat die Möglichkeit, die Fahrt erneut abzuschließen.

Mit diesem PR wurden für das TripDetailsFragment bereits die State-Views aus #19 umgesetzt.