### PR TITLE
BugFix: Türen nach Reihenfolge unabhängig von der Selektion anzeigen

### DIFF
--- a/app/src/main/java/de/vdvcount/app/adapter/DoorListAdapter.java
+++ b/app/src/main/java/de/vdvcount/app/adapter/DoorListAdapter.java
@@ -5,6 +5,8 @@ import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import androidx.annotation.NonNull;
@@ -40,6 +42,7 @@ public class DoorListAdapter extends RecyclerView.Adapter<DoorListAdapter.ViewHo
     public List<String> getSelectedDoorList() {
         List<String> selectedDoorList = new ArrayList<>();
 
+        Collections.sort(this.selectedDoorIndices);
         for (int index : this.selectedDoorIndices) {
             selectedDoorList.add(this.doorList.get(index));
         }


### PR DESCRIPTION
Bislang wurden die Türen in der Zählansicht in der Reihenfolge angezeigt, in der sie in der Vorauswahl selektiert wurden. 

Mit diesem Fix werden die Türen nun immer in der korrekten Reihenfolge (wie auch in der Vorauswahl) angezeigt, unabhängig davon, in welcher Reihenfolge sie selektiert wurden.