### PR TITLE
UI-Optimierung Fahrtansicht

### DIFF
--- a/app/src/main/java/de/vdvcount/app/common/Status.java
+++ b/app/src/main/java/de/vdvcount/app/common/Status.java
@@ -18,6 +18,8 @@ public class Status extends KeyValueStore {
     public final static String LAST_COUNTED_DOOR_IDS = "de.vdvcount.app.kvs.status.LAST_COUNTED_DOOR_IDS";
     public final static String STAY_IN_VEHICLE = "de.vdvcount.app.kvs.status.STAY_IN_VEHICLE";
 
+    public final static String VIEW_TRIP_DETAILS_SCROLL_POSITION = "de.vdvcount.app.kvs.status.VIEW_TRIP_DETAILS_SCROLL_POSITION";
+
     public static class Values {
         public final static String INITIAL = "INITIAL";
         public final static String READY = "READY";

--- a/app/src/main/java/de/vdvcount/app/dialog/CountingActionDialog.java
+++ b/app/src/main/java/de/vdvcount/app/dialog/CountingActionDialog.java
@@ -2,14 +2,15 @@ package de.vdvcount.app.dialog;
 
 import android.app.AlertDialog;
 import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Color;
+import android.os.Handler;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 
-import androidx.annotation.DrawableRes;
+import androidx.core.content.ContextCompat;
 import androidx.databinding.DataBindingUtil;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 import de.vdvcount.app.R;
 import de.vdvcount.app.databinding.DialogCountingActionBinding;
@@ -17,13 +18,25 @@ import de.vdvcount.app.databinding.DialogCountingActionBinding;
 public class CountingActionDialog {
 
     private Context context;
+    private DialogCountingActionBinding dataBinding;
 
     private View.OnClickListener onActionCountingClickListener;
     private View.OnClickListener onActionAdditionalStopClickListener;
     private View.OnClickListener onActionRunThroughListener;
 
+    private boolean secondRunThroughClick;
+    private Runnable runThroughResetRunnable;
+    private Handler runThroughResetHandler;
+
     public CountingActionDialog(Context context) {
         this.context = context;
+
+        this.runThroughResetRunnable = () -> {
+            this.secondRunThroughClick = false;
+            this.dataBinding.layoutActionRunThrough.setBackgroundResource(this.getThemeResource(this.context, androidx.appcompat.R.attr.selectableItemBackground));
+        };
+
+        this.runThroughResetHandler = new Handler();
     }
 
     public void setOnActionCountingClickListener(View.OnClickListener listener) {
@@ -39,46 +52,83 @@ public class CountingActionDialog {
     }
 
     public void show() {
-        DialogCountingActionBinding dataBinding = DataBindingUtil.inflate(LayoutInflater.from(this.context), R.layout.dialog_counting_action, null, false);
+        this.dataBinding = DataBindingUtil.inflate(LayoutInflater.from(this.context), R.layout.dialog_counting_action, null, false);
 
         final AlertDialog alertDialog = new AlertDialog.Builder(this.context)
-                .setView(dataBinding.getRoot())
+                .setView(this.dataBinding.getRoot())
                 .setCancelable(true)
                 .create();
 
         if (this.onActionCountingClickListener != null) {
-            dataBinding.layoutActionCount.setVisibility(View.VISIBLE);
-            dataBinding.layoutActionCount.setOnClickListener(view -> {
+            this.dataBinding.layoutActionCount.setVisibility(View.VISIBLE);
+            this.dataBinding.layoutActionCount.setOnClickListener(view -> {
                 alertDialog.hide();
 
                 this.onActionCountingClickListener.onClick(view);
             });
         } else {
-            dataBinding.layoutActionCount.setVisibility(View.GONE);
+            this.dataBinding.layoutActionCount.setVisibility(View.GONE);
         }
 
         if (this.onActionAdditionalStopClickListener != null) {
-            dataBinding.layoutActionAdditionalStop.setVisibility(View.VISIBLE);
-            dataBinding.layoutActionAdditionalStop.setOnClickListener(view -> {
+            this.dataBinding.layoutActionAdditionalStop.setVisibility(View.VISIBLE);
+            this.dataBinding.layoutActionAdditionalStop.setOnClickListener(view -> {
                 alertDialog.hide();
 
                 this.onActionAdditionalStopClickListener.onClick(view);
             });
         } else {
-            dataBinding.layoutActionAdditionalStop.setVisibility(View.GONE);
+            this.dataBinding.layoutActionAdditionalStop.setVisibility(View.GONE);
         }
 
         if (this.onActionRunThroughListener != null) {
-            dataBinding.layoutActionRunThrough.setVisibility(View.VISIBLE);
-            dataBinding.layoutActionRunThrough.setOnClickListener(view -> {
-                alertDialog.hide();
+            this.dataBinding.layoutActionRunThrough.setVisibility(View.VISIBLE);
+            this.dataBinding.layoutActionRunThrough.setOnClickListener(view -> {
+                if (!this.secondRunThroughClick) {
+                    this.secondRunThroughClick = true;
+                    this.runThroughResetHandler.postDelayed(this.runThroughResetRunnable, 2000);
 
-                this.onActionRunThroughListener.onClick(view);
+                    this.dataBinding.layoutActionRunThrough.setBackgroundColor(this.getThemeColor(this.context, androidx.appcompat.R.attr.colorPrimary));
+                } else {
+                    this.runThroughResetHandler.removeCallbacks(this.runThroughResetRunnable);
+
+                    alertDialog.hide();
+
+                    this.onActionRunThroughListener.onClick(view);
+                }
             });
         } else {
-            dataBinding.layoutActionRunThrough.setVisibility(View.GONE);
+            this.dataBinding.layoutActionRunThrough.setVisibility(View.GONE);
         }
 
         alertDialog.show();
+    }
+
+    public int getThemeColor(Context context, int attrResId) {
+        TypedValue typedValue = new TypedValue();
+        Resources.Theme theme = context.getTheme();
+        if (theme.resolveAttribute(attrResId, typedValue, true)) {
+            if (typedValue.resourceId != 0) {
+                return ContextCompat.getColor(context, typedValue.resourceId);
+            } else {
+                return typedValue.data;
+            }
+        }
+
+        return Color.TRANSPARENT;
+    }
+
+    public int getThemeResource(Context context, int attrResId) {
+        TypedValue outValue = new TypedValue();
+        Resources.Theme theme = context.getTheme();
+        if(theme.resolveAttribute(attrResId, outValue, true)) {
+            if (outValue.resourceId != 0) {
+                return outValue.resourceId;
+            } else {
+                return outValue.data;
+            }
+        }
+
+        throw new Resources.NotFoundException(String.format("could not resolve attrResId %d", attrResId));
     }
 }

--- a/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsFragment.java
+++ b/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsFragment.java
@@ -1,11 +1,9 @@
 package de.vdvcount.app.ui.tripdetails;
 
 import androidx.databinding.DataBindingUtil;
-import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 
 import android.content.Context;
-import android.location.Location;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -142,6 +140,8 @@ public class TripDetailsFragment extends Fragment {
             action.setLastStationId(lastCountedStopTime.getStop().getParentId());
             action.setLastStationName(lastCountedStopTime.getStop().getName());
 
+            this.resetCurrentVerticalScrollPosition();
+
             this.navigationController.navigate(action);
         });
 
@@ -154,6 +154,12 @@ public class TripDetailsFragment extends Fragment {
                         Status.getString(Status.CURRENT_VEHICLE_ID, ""),
                         Status.getInt(Status.CURRENT_START_STOP_SEQUENCE, -1)
                 );
+            }
+        });
+
+        this.dataBinding.scrollView.getViewTreeObserver().addOnGlobalLayoutListener(() -> {
+            if (this.getCurrentVerticalScrollPosition() != -1) {
+                this.dataBinding.scrollView.post(() -> this.dataBinding.scrollView.scrollTo(0, this.getCurrentVerticalScrollPosition()));
             }
         });
     }
@@ -200,6 +206,8 @@ public class TripDetailsFragment extends Fragment {
 
         if (actionCountingEnabled) {
             dialog.setOnActionCountingClickListener(view -> {
+                this.setCurrentVerticalScrollPosition();
+
                 TripDetailsFragmentDirections.ActionTripDetailsFragmentToCountingFragment action = TripDetailsFragmentDirections.actionTripDetailsFragmentToCountingFragment(
                         Status.getStringArray(Status.CURRENT_COUNTED_DOOR_IDS, new String[] {})
                 );
@@ -213,6 +221,8 @@ public class TripDetailsFragment extends Fragment {
 
         if (actionAdditionalStopEnabled) {
             dialog.setOnActionAdditionalStopClickListener(view -> {
+                this.setCurrentVerticalScrollPosition();
+
                 TripDetailsFragmentDirections.ActionTripDetailsFragmentToCountingFragment action = TripDetailsFragmentDirections.actionTripDetailsFragmentToCountingFragment(
                         Status.getStringArray(Status.CURRENT_COUNTED_DOOR_IDS, new String[] {})
                 );
@@ -225,6 +235,8 @@ public class TripDetailsFragment extends Fragment {
 
         if (actionRunThroughEnabled) {
             dialog.setOnActionRunThroughListener(view -> {
+                this.setCurrentVerticalScrollPosition();
+
                 String[] permissions = {
                         android.Manifest.permission.ACCESS_FINE_LOCATION,
                         android.Manifest.permission.CAMERA
@@ -249,6 +261,18 @@ public class TripDetailsFragment extends Fragment {
         }
 
         dialog.show();
+    }
+
+    private int getCurrentVerticalScrollPosition() {
+        return Status.getInt(Status.VIEW_TRIP_DETAILS_SCROLL_POSITION, -1);
+    }
+
+    private void resetCurrentVerticalScrollPosition() {
+        Status.setInt(Status.VIEW_TRIP_DETAILS_SCROLL_POSITION, -1);
+    }
+
+    private void setCurrentVerticalScrollPosition() {
+        Status.setInt(Status.VIEW_TRIP_DETAILS_SCROLL_POSITION, this.dataBinding.scrollView.getScrollY());
     }
 
     public enum State {

--- a/app/src/main/res/layout/fragment_trip_details.xml
+++ b/app/src/main/res/layout/fragment_trip_details.xml
@@ -22,6 +22,7 @@
         android:layout_height="match_parent">
 
         <androidx.core.widget.NestedScrollView
+            android:id="@+id/scrollView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:visibility="@{viewModel.state == TripDetailsFragment.State.READY || viewModel.state == TripDetailsFragment.State.LOADING ? View.VISIBLE : View.GONE}">


### PR DESCRIPTION
Die UI der Fahrtansicht wurde optimiert, sodass nun nach dem Erstellen eines PCE oder einer Durchfahrt die Scrollposition erhalten bleibt. Außerdem wurde der Dialog für die Aktionsauswahl (Zählung, Zwischenhalt, Durchfahrt) so überarbeitet, dass die Durchfahrt erst erzeugt wird, wenn der Button dazu ein zweites Mal innerhalb von 2s angeklickt wurde.