### PR TITLE
UI-Optimierung Haltestellenauswahl

### DIFF
--- a/app/src/main/java/de/vdvcount/app/ui/stationselect/StationSelectFragment.java
+++ b/app/src/main/java/de/vdvcount/app/ui/stationselect/StationSelectFragment.java
@@ -144,6 +144,10 @@ public class StationSelectFragment extends Fragment {
             }
         });
 
+        this.dataBinding.imgClearStopName.setOnClickListener(view -> {
+            this.dataBinding.edtStopName.setText("");
+        });
+
         this.stopListAdapter.setOnItemClickListener(station -> {
             // if the stay-in-vehicle flag is set but the user changes the stop, this is no trip connection anymore...
             // reset the flag for this reason

--- a/app/src/main/res/drawable/ic_clear.xml
+++ b/app/src/main/res/drawable/ic_clear.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+    
+</vector>

--- a/app/src/main/res/layout/fragment_stop_select.xml
+++ b/app/src/main/res/layout/fragment_stop_select.xml
@@ -3,38 +3,57 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/edtStopNameLayout"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/app_default_spacing"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent">
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/edtStopName"
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/edtStopNameLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/stop_select_stop_name_hint" />
+                android:layout_margin="@dimen/app_default_spacing"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent">
 
-        </com.google.android.material.textfield.TextInputLayout>
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/edtStopName"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/stop_select_stop_name_hint" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <ImageView
+                android:id="@+id/imgClearStopName"
+                android:layout_width="26dp"
+                android:layout_height="26dp"
+                android:layout_marginTop="@dimen/app_default_spacing"
+                android:layout_marginEnd="@dimen/app_medium_spacing"
+                android:src="@drawable/ic_clear"
+                app:tint="@color/gray"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/lstStops"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_marginTop="@dimen/app_default_spacing"
-            app:layout_constraintTop_toBottomOf="@id/edtStopNameLayout"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
+            android:layout_weight="1"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"/>
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
 
 </layout>


### PR DESCRIPTION
Das Textfeld in der Haltestellenauswahl wurde mit einem simplen Clear-Button versehen, um schnell die aktuelle Haltestelle zu löschen und direkt eine neue Haltestelle suchen zu können.