### PR TITLE
Möglichkeit zum Abbruch der Zählfahrt

### DIFF
--- a/app/src/main/java/de/vdvcount/app/dialog/CountingActionDialog.java
+++ b/app/src/main/java/de/vdvcount/app/dialog/CountingActionDialog.java
@@ -33,7 +33,9 @@ public class CountingActionDialog {
 
         this.runThroughResetRunnable = () -> {
             this.secondRunThroughClick = false;
+
             this.dataBinding.layoutActionRunThrough.setBackgroundResource(this.getThemeResource(this.context, androidx.appcompat.R.attr.selectableItemBackground));
+            this.dataBinding.lblRunThroughText.setText(R.string.dialog_counting_action_run_through);
         };
 
         this.runThroughResetHandler = new Handler();
@@ -89,6 +91,7 @@ public class CountingActionDialog {
                     this.runThroughResetHandler.postDelayed(this.runThroughResetRunnable, 2000);
 
                     this.dataBinding.layoutActionRunThrough.setBackgroundColor(this.getThemeColor(this.context, androidx.appcompat.R.attr.colorPrimary));
+                    this.dataBinding.lblRunThroughText.setText(R.string.dialog_counting_action_run_through_confirmation);
                 } else {
                     this.runThroughResetHandler.removeCallbacks(this.runThroughResetRunnable);
 

--- a/app/src/main/java/de/vdvcount/app/filesystem/FilesystemRepository.java
+++ b/app/src/main/java/de/vdvcount/app/filesystem/FilesystemRepository.java
@@ -48,6 +48,12 @@ public class FilesystemRepository {
         return countedTrip;
     }
 
+    public void cancelCountedTrip() {
+        Logging.i(this.getClass().getName(), "Counted cancellation requested");
+
+        this.closeCountedTrip();
+    }
+
     public void updateCountedTrip(CountedTrip countedTrip) {
         String countedTripFilename = this.getCountedTripFilename();
 
@@ -118,7 +124,9 @@ public class FilesystemRepository {
     public void closeCountedTrip() {
         String countedTripFilename = this.getCountedTripFilename();
         File file = new File(countedTripFilename);
-        file.delete();
+        if (file.exists()) {
+            file.delete();
+        }
 
         Logging.i(this.getClass().getName(), "Removed CountedTrip object from local storage");
     }

--- a/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsFragment.java
+++ b/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsFragment.java
@@ -15,6 +15,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
+import android.os.Handler;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -49,12 +50,23 @@ public class TripDetailsFragment extends Fragment {
     private CountedTripAdapter countedTripAdapter;
     private LocationWarningDialog locationWarningDialog;
 
+    private boolean secondCancellationClick;
+    private Runnable cancellationResetRunnable;
+    private Handler cancellationResetHandler;
+
     public static TripDetailsFragment newInstance() {
         return new TripDetailsFragment();
     }
 
     public TripDetailsFragment() {
         this.countedTripAdapter = new CountedTripAdapter();
+
+        this.cancellationResetRunnable = () -> {
+            this.secondCancellationClick = false;
+            this.dataBinding.btnCancel.setText(R.string.trip_details_cancel);
+        };
+
+        this.cancellationResetHandler = new Handler();
     }
 
     @Override
@@ -141,10 +153,19 @@ public class TripDetailsFragment extends Fragment {
 
     private void initViewEvents() {
         this.dataBinding.btnCancel.setOnClickListener(view -> {
-            this.viewModel.cancelCountedTrip();
+            if (!this.secondCancellationClick) {
+                this.secondCancellationClick = true;
 
-            TripDetailsFragmentDirections.ActionTripDetailsFragmentToDepartureFragment action = TripDetailsFragmentDirections.actionTripDetailsFragmentToDepartureFragment();
-            this.navigationController.navigate(action);
+                this.cancellationResetHandler.postDelayed(this.cancellationResetRunnable, 2000);
+                this.dataBinding.btnCancel.setText(R.string.trip_details_cancel_confirmation);
+            } else {
+                this.cancellationResetHandler.removeCallbacks(this.cancellationResetRunnable);
+
+                this.viewModel.cancelCountedTrip();
+
+                TripDetailsFragmentDirections.ActionTripDetailsFragmentToDepartureFragment action = TripDetailsFragmentDirections.actionTripDetailsFragmentToDepartureFragment();
+                this.navigationController.navigate(action);
+            }
         });
 
         this.dataBinding.btnQuit.setOnClickListener(view -> {

--- a/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsFragment.java
+++ b/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsFragment.java
@@ -140,6 +140,13 @@ public class TripDetailsFragment extends Fragment {
     }
 
     private void initViewEvents() {
+        this.dataBinding.btnCancel.setOnClickListener(view -> {
+            this.viewModel.cancelCountedTrip();
+
+            TripDetailsFragmentDirections.ActionTripDetailsFragmentToDepartureFragment action = TripDetailsFragmentDirections.actionTripDetailsFragmentToDepartureFragment();
+            this.navigationController.navigate(action);
+        });
+
         this.dataBinding.btnQuit.setOnClickListener(view -> {
             CountedTrip countedTrip = this.viewModel.getCountedTrip().getValue();
             CountedStopTime lastCountedStopTime = countedTrip.getCountedStopTimes().get(countedTrip.getCountedStopTimes().size() - 1);

--- a/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsViewModel.java
+++ b/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsViewModel.java
@@ -97,6 +97,21 @@ public class TripDetailsViewModel extends ViewModel {
         thread.start();
     }
 
+    public void cancelCountedTrip() {
+        Runnable runnable = () -> {
+            FilesystemRepository filesystemRepository = FilesystemRepository.getInstance();
+            filesystemRepository.cancelCountedTrip();
+
+            Status.setString(Status.STATUS, Status.Values.READY);
+            Status.setInt(Status.CURRENT_TRIP_ID, -1);
+            Status.setInt(Status.CURRENT_START_STOP_SEQUENCE, -1);
+            Status.setString(Status.CURRENT_VEHICLE_ID, "");
+        };
+
+        Thread thread = new Thread(runnable);
+        thread.start();
+    }
+
     public void addRunThroughPassengerCountingEvent(int stopSequence) {
         Logging.i(this.getClass().getName(), "Adding run-through PCE");
 

--- a/app/src/main/res/layout/dialog_counting_action.xml
+++ b/app/src/main/res/layout/dialog_counting_action.xml
@@ -91,6 +91,7 @@
                 app:tint="?attr/defaultIconColor" />
 
             <TextView
+                android:id="@+id/lblRunThroughText"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_margin="@dimen/app_default_spacing"

--- a/app/src/main/res/layout/fragment_trip_details.xml
+++ b/app/src/main/res/layout/fragment_trip_details.xml
@@ -47,6 +47,21 @@
                         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"  />
 
                     <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btnCancel"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/app_medium_spacing"
+                        android:layout_marginStart="@dimen/app_default_spacing"
+                        android:layout_marginEnd="@dimen/app_default_spacing"
+                        android:layout_marginBottom="8dp"
+                        android:text="@string/trip_details_cancel"
+                        app:backgroundTint="@color/color_danger"
+                        app:layout_constraintTop_toBottomOf="@id/lstCountedStopTimes"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintBottom_toBottomOf="parent" />
+
+                    <com.google.android.material.button.MaterialButton
                         android:id="@+id/btnQuit"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -55,7 +70,7 @@
                         android:layout_marginEnd="@dimen/app_default_spacing"
                         android:layout_marginBottom="8dp"
                         android:text="@string/trip_details_quit"
-                        app:layout_constraintTop_toBottomOf="@id/lstCountedStopTimes"
+                        app:layout_constraintTop_toBottomOf="@id/btnCancel"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintBottom_toBottomOf="parent" />

--- a/app/src/main/res/layout/fragment_trip_details.xml
+++ b/app/src/main/res/layout/fragment_trip_details.xml
@@ -50,7 +50,7 @@
                         android:id="@+id/btnCancel"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/app_medium_spacing"
+                        android:layout_marginTop="@dimen/app_large_spacing"
                         android:layout_marginStart="@dimen/app_default_spacing"
                         android:layout_marginEnd="@dimen/app_default_spacing"
                         android:layout_marginBottom="8dp"
@@ -59,13 +59,13 @@
                         app:layout_constraintTop_toBottomOf="@id/lstCountedStopTimes"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintBottom_toBottomOf="parent" />
+                        app:layout_constraintBottom_toTopOf="@id/btnQuit" />
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/btnQuit"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/app_medium_spacing"
+                        android:layout_marginTop="@dimen/app_default_spacing"
                         android:layout_marginStart="@dimen/app_default_spacing"
                         android:layout_marginEnd="@dimen/app_default_spacing"
                         android:layout_marginBottom="8dp"

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -144,6 +144,12 @@
         <action
             android:id="@+id/action_tripDetailsFragment_to_tripClosingFragment"
             app:destination="@id/tripClosingFragment" />
+        <action
+            android:id="@+id/action_tripDetailsFragment_to_departureFragment"
+            app:destination="@id/departureFragment"
+            app:launchSingleTop="true"
+            app:popUpTo="@id/navigation_graph.xml"
+            app:popUpToInclusive="true" />
     </fragment>
     <fragment
         android:id="@+id/countingFragment"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,4 +9,5 @@
     <color name="color_secondary_200">#CACACA</color>
     <color name="color_secondary_600">#9e9e9e</color>
     <color name="color_primary_selection">#E7C83D</color>
+    <color name="color_danger">#E01919</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
 
     <!-- TripDetailsFragment -->
     <string name="trip_details_title">Zählfahrt</string>
+    <string name="trip_details_cancel">Fahrt abbrechen</string>
     <string name="trip_details_quit">Fahrt abschließen</string>
 
     <!-- TripClosingFragment -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,7 @@
     <string name="dialog_counting_action_counting">Zählung</string>
     <string name="dialog_counting_action_additional_stop">Zwischenhalt</string>
     <string name="dialog_counting_action_run_through">Durchfahrt</string>
+    <string name="dialog_counting_action_run_through_confirmation">Durchfahrt erfassen?</string>
 
     <!-- GPS Warning Dialog -->
     <string name="dialog_gps_warning_title">Kein Standort</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <!-- TripDetailsFragment -->
     <string name="trip_details_title">Zählfahrt</string>
     <string name="trip_details_cancel">Fahrt abbrechen</string>
+    <string name="trip_details_cancel_confirmation">Fahrt wirklich abbrechen?</string>
     <string name="trip_details_quit">Fahrt abschließen</string>
 
     <!-- TripClosingFragment -->


### PR DESCRIPTION
Die VdvCountApp wurde entsprechend erweitert, sodass eine begonnene Zählfahrt abgebrochen werden kann, ohne Datenmüll zu erzeugen. Im unteren Bereich wird dazu ein Button "Zählung abbrechen" angezeigt. Dieser muss 2x (einmal zum Abbrechen, einmal zum Bestätigen) geklickt werden, damit die Zählung abgebrochen und zur ursprünglichen Haltestelle zurückgekehrt wird.

In diesem Fall wird die gesamte Zählfahrt restlos verworfen, es werden keine Daten an VdvCountCore übermittelt. Der Abbruch wird lediglich in den Logs erfasst.