### PR TITLE
Erweiterung der Ergebnisdaten um das Feld vehicle_num_doors

### DIFF
--- a/app/src/main/java/de/vdvcount/app/AppActivity.java
+++ b/app/src/main/java/de/vdvcount/app/AppActivity.java
@@ -115,6 +115,7 @@ public class AppActivity extends AppCompatActivity {
                 Status.setInt(Status.CURRENT_TRIP_ID, -1);
                 Status.setInt(Status.CURRENT_START_STOP_SEQUENCE, -1);
                 Status.setString(Status.CURRENT_VEHICLE_ID, null);
+                Status.setInt(Status.CURRENT_VEHICLE_NUM_DOORS, -1);
                 Status.setStringArray(Status.CURRENT_COUNTED_DOOR_IDS, new String[] {});
 
                 this.finish();

--- a/app/src/main/java/de/vdvcount/app/common/Status.java
+++ b/app/src/main/java/de/vdvcount/app/common/Status.java
@@ -11,6 +11,7 @@ public class Status extends KeyValueStore {
     public final static String CURRENT_TRIP_ID = "de.vdvcount.app.kvs.status.CURRENT_TRIP_ID";
     public final static String CURRENT_START_STOP_SEQUENCE = "de.vdvcount.app.kvs.status.CURRENT_START_STOP_SEQUENCE";
     public final static String CURRENT_VEHICLE_ID = "de.vdvcount.app.kvs.status.CURRENT_VEHICLE_ID";
+    public final static String CURRENT_VEHICLE_NUM_DOORS = "de.vdvcount.app.kvs.status.CURRENT_VEHICLE_NUM_DOORS";
     public final static String CURRENT_COUNTED_DOOR_IDS = "de.vdvcount.app.kvs.status.CURRENT_COUNTED_DOOR_IDS";
 
     public final static String LAST_PCE = "de.vdvcount.app.kvs.status.LAST_PCE";

--- a/app/src/main/java/de/vdvcount/app/filesystem/FilesystemRepository.java
+++ b/app/src/main/java/de/vdvcount/app/filesystem/FilesystemRepository.java
@@ -37,9 +37,10 @@ public class FilesystemRepository {
         this.verifyFileSystemStructure();
     }
 
-    public CountedTrip startCountedTrip(Trip trip, String vehicleId) {
+    public CountedTrip startCountedTrip(Trip trip, String vehicleId, int vehicleNumDoors) {
         CountedTrip countedTrip = CountedTrip.from(trip);
         countedTrip.setVehicleId(vehicleId);
+        countedTrip.setVehicleNumDoors(vehicleNumDoors);
 
         this.updateCountedTrip(countedTrip);
 

--- a/app/src/main/java/de/vdvcount/app/model/CountedTrip.java
+++ b/app/src/main/java/de/vdvcount/app/model/CountedTrip.java
@@ -16,6 +16,7 @@ public class CountedTrip extends Trip implements ApiObjectMapper<CountedTripObje
     private String vcaVersion;
     private String deviceId;
     private String vehicleId;
+    private int vehicleNumDoors;
     private List<CountedStopTime> countedStopTimes;
     private List<PassengerCountingEvent> unmatchedPassengerCountingEvents;
     private List<WayPoint> wayPoints;
@@ -83,6 +84,14 @@ public class CountedTrip extends Trip implements ApiObjectMapper<CountedTripObje
         this.vehicleId = vehicleId;
     }
 
+    public int getVehicleNumDoors() {
+        return this.vehicleNumDoors;
+    }
+
+    public void setVehicleNumDoors(int vehicleNumDoors) {
+        this.vehicleNumDoors = vehicleNumDoors;
+    }
+
     public List<CountedStopTime> getCountedStopTimes() {
         return this.countedStopTimes;
     }
@@ -121,6 +130,7 @@ public class CountedTrip extends Trip implements ApiObjectMapper<CountedTripObje
         apiObject.setVcaVersion(this.getVcaVersion());
         apiObject.setDeviceId(this.getDeviceId());
         apiObject.setVehicleId(this.getVehicleId());
+        apiObject.setVehicleNumDoors(this.getVehicleNumDoors());
 
         List<CountedStopTimeObject> countedStopTimes = new ArrayList<>();
         for (CountedStopTime obj : this.getCountedStopTimes()) {

--- a/app/src/main/java/de/vdvcount/app/remote/CountedTripObject.java
+++ b/app/src/main/java/de/vdvcount/app/remote/CountedTripObject.java
@@ -18,6 +18,8 @@ public class CountedTripObject extends TripObject {
     private String deviceId;
     @SerializedName("vehicle_id")
     private String vehicleId;
+    @SerializedName("vehicle_num_doors")
+    private int vehicleNumDoors;
     @SerializedName("counted_stop_times")
     private List<CountedStopTimeObject> countedStopTimes;
     @SerializedName("unmatched_passenger_counting_events")
@@ -65,6 +67,14 @@ public class CountedTripObject extends TripObject {
         this.vehicleId = vehicleId;
     }
 
+    public int getVehicleNumDoors() {
+        return this.vehicleNumDoors;
+    }
+
+    public void setVehicleNumDoors(int vehicleNumDoors) {
+        this.vehicleNumDoors = vehicleNumDoors;
+    }
+
     public List<CountedStopTimeObject> getCountedStopTimes() {
         return this.countedStopTimes;
     }
@@ -103,6 +113,7 @@ public class CountedTripObject extends TripObject {
         domainModel.setVcaVersion(this.getVcaVersion());
         domainModel.setDeviceId(this.getDeviceId());
         domainModel.setVehicleId(this.getVehicleId());
+        domainModel.setVehicleNumDoors(this.getVehicleNumDoors());
 
         List<CountedStopTime> countedStopTimes = new ArrayList<>();
         for (CountedStopTimeObject obj : this.getCountedStopTimes()) {

--- a/app/src/main/java/de/vdvcount/app/ui/tripclosing/TripClosingViewModel.java
+++ b/app/src/main/java/de/vdvcount/app/ui/tripclosing/TripClosingViewModel.java
@@ -63,6 +63,7 @@ public class TripClosingViewModel extends ViewModel {
                 Status.setInt(Status.CURRENT_TRIP_ID, -1);
                 Status.setInt(Status.CURRENT_START_STOP_SEQUENCE, -1);
                 Status.setString(Status.CURRENT_VEHICLE_ID, "");
+                Status.setInt(Status.CURRENT_VEHICLE_NUM_DOORS, -1);
 
                 if (stayInVehicle) {
                     String[] countedDoorIds = Status.getStringArray(Status.CURRENT_COUNTED_DOOR_IDS, new String[] {});

--- a/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsFragment.java
+++ b/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsFragment.java
@@ -85,6 +85,10 @@ public class TripDetailsFragment extends Fragment {
             Status.setString(Status.CURRENT_VEHICLE_ID, args.getVehicleId());
         }
 
+        if (args.getVehicleNumDoors() != -1) {
+            Status.setInt(Status.CURRENT_VEHICLE_NUM_DOORS, args.getVehicleNumDoors());
+        }
+
         if (args.getStartStopSequence() != -1) {
             Status.setInt(Status.CURRENT_START_STOP_SEQUENCE, args.getStartStopSequence());
         }

--- a/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsFragment.java
+++ b/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsFragment.java
@@ -110,6 +110,7 @@ public class TripDetailsFragment extends Fragment {
                 this.viewModel.startCountedTrip(
                         Status.getInt(Status.CURRENT_TRIP_ID, -1),
                         Status.getString(Status.CURRENT_VEHICLE_ID, ""),
+                        Status.getInt(Status.CURRENT_VEHICLE_NUM_DOORS, -1),
                         Status.getInt(Status.CURRENT_START_STOP_SEQUENCE, -1)
                 );
             } else {
@@ -188,6 +189,7 @@ public class TripDetailsFragment extends Fragment {
                 this.viewModel.startCountedTrip(
                         Status.getInt(Status.CURRENT_TRIP_ID, -1),
                         Status.getString(Status.CURRENT_VEHICLE_ID, ""),
+                        Status.getInt(Status.CURRENT_VEHICLE_NUM_DOORS, -1),
                         Status.getInt(Status.CURRENT_START_STOP_SEQUENCE, -1)
                 );
             }

--- a/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsViewModel.java
+++ b/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsViewModel.java
@@ -88,6 +88,7 @@ public class TripDetailsViewModel extends ViewModel {
                 Status.setInt(Status.CURRENT_TRIP_ID, tripId);
                 Status.setInt(Status.CURRENT_START_STOP_SEQUENCE, startStopSequence);
                 Status.setString(Status.CURRENT_VEHICLE_ID, vehicleId);
+                Status.setInt(Status.CURRENT_VEHICLE_NUM_DOORS, vehicleNumDoors);
             } else {
                 this.state.postValue(TripDetailsFragment.State.ERROR);
             }

--- a/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsViewModel.java
+++ b/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsViewModel.java
@@ -43,7 +43,7 @@ public class TripDetailsViewModel extends ViewModel {
         return this.countedTrip;
     }
 
-    public void startCountedTrip(int tripId, String vehicleId, int startStopSequence) {
+    public void startCountedTrip(int tripId, String vehicleId, int vehicleNumDoors, int startStopSequence) {
         Runnable runnable = () -> {
             this.state.postValue(TripDetailsFragment.State.LOADING);
 
@@ -52,7 +52,7 @@ public class TripDetailsViewModel extends ViewModel {
 
             if (trip != null) {
                 FilesystemRepository filesystemRepository = FilesystemRepository.getInstance();
-                CountedTrip countedTrip = filesystemRepository.startCountedTrip(trip, vehicleId);
+                CountedTrip countedTrip = filesystemRepository.startCountedTrip(trip, vehicleId, vehicleNumDoors);
 
                 if (Status.getBoolean(Status.STAY_IN_VEHICLE, false)) {
                     String passengerCountingEventJson = Status.getString(Status.LAST_PCE, null);

--- a/app/src/main/java/de/vdvcount/app/ui/tripparams/TripParamsFragment.java
+++ b/app/src/main/java/de/vdvcount/app/ui/tripparams/TripParamsFragment.java
@@ -39,6 +39,7 @@ public class TripParamsFragment extends Fragment {
 
     private int currentTripId;
     private String currentVehicleId;
+    private int currentVehicleNumDoors;
     private VehicleListAdapter vehicleListAdapter;
     private DoorListAdapter doorListAdapter;
     private TextWatcher vehicleIdTextWatcher;
@@ -56,6 +57,7 @@ public class TripParamsFragment extends Fragment {
             @Override
             public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
                 currentVehicleId = null;
+                currentVehicleNumDoors = -1;
                 doorListAdapter.setDoorList(new ArrayList<>());
 
                 validateInputs();
@@ -146,6 +148,7 @@ public class TripParamsFragment extends Fragment {
         this.dataBinding.edtVehicle.setOnItemClickListener((adapterView, view, i, l) -> {
             Vehicle vehicle = this.vehicleListAdapter.getItem(i);
             this.currentVehicleId = vehicle.getName();
+            this.currentVehicleNumDoors = vehicle.getNumDoors();
 
             this.createDoorList(vehicle);
 
@@ -163,6 +166,8 @@ public class TripParamsFragment extends Fragment {
                     0,
                     this.doorListAdapter.getSelectedDoorList().toArray(new String[0])
             );
+
+            action.setVehicleNumDoors(this.currentVehicleNumDoors);
 
             this.navigationController.navigate(action);
         });

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -120,6 +120,10 @@
             app:argType="string"
             app:nullable="true" />
         <argument
+            android:name="vehicleNumDoors"
+            app:argType="integer"
+            android:defaultValue="-1" />
+        <argument
             android:name="startStopSequence"
             app:argType="integer" />
         <argument


### PR DESCRIPTION
Die Ergebnisdaten wurden um das Feld `vehicle_num_doors` erweitert, sodass der VDV457-Export in VCC prüfen kann, ob jede Tür eines Fahrzeuges mindestens einmal geliefert wurde.

Auf die UI oder Bedienung hat das keinerlei Auswirkung, die Daten werden im Hintergrund einfach mit verarbeitet.