### PR TITLE
Direkter Absprung zur Folgefahrt bei Durchfahrt

### DIFF
--- a/app/src/main/java/de/vdvcount/app/model/CountedTrip.java
+++ b/app/src/main/java/de/vdvcount/app/model/CountedTrip.java
@@ -152,4 +152,15 @@ public class CountedTrip extends Trip implements ApiObjectMapper<CountedTripObje
 
         return apiObject;
     }
+
+    public PassengerCountingEvent getLastPce() {
+        CountedStopTime lastCountedStopTime = this.getCountedStopTimes().get(this.getCountedStopTimes().size() - 1);
+
+        PassengerCountingEvent lastPassengerCountingEvent = null;
+        if (!lastCountedStopTime.getPassengerCountingEvents().isEmpty()) {
+            lastPassengerCountingEvent = lastCountedStopTime.getPassengerCountingEvents().get(lastCountedStopTime.getPassengerCountingEvents().size() - 1);
+        }
+
+        return lastPassengerCountingEvent;
+    }
 }

--- a/app/src/main/java/de/vdvcount/app/model/PassengerCountingEvent.java
+++ b/app/src/main/java/de/vdvcount/app/model/PassengerCountingEvent.java
@@ -113,4 +113,10 @@ public class PassengerCountingEvent implements ApiObjectMapper<PassengerCounting
 
         return passengerCountingEventObject.mapDomainModel();
     }
+
+    public PassengerCountingEvent copy()
+    {
+        String serialized = this.serialize();
+        return PassengerCountingEvent.deserialize(serialized);
+    }
 }

--- a/app/src/main/java/de/vdvcount/app/ui/tripclosing/TripClosingViewModel.java
+++ b/app/src/main/java/de/vdvcount/app/ui/tripclosing/TripClosingViewModel.java
@@ -34,7 +34,7 @@ public class TripClosingViewModel extends ViewModel {
             CountedTrip countedTrip = filesystemRepository.loadCountedTrip();
 
             if (stayInVehicle) {
-                PassengerCountingEvent passengerCountingEvent = this.extractLastPce(countedTrip);
+                PassengerCountingEvent passengerCountingEvent = countedTrip.getLastPce();
                 Status.setString(Status.LAST_PCE, passengerCountingEvent != null ? passengerCountingEvent.serialize() : null);
 
                 if (passengerCountingEvent != null) {
@@ -79,16 +79,5 @@ public class TripClosingViewModel extends ViewModel {
 
         Thread thread = new Thread(runnable);
         thread.start();
-    }
-
-    private PassengerCountingEvent extractLastPce(CountedTrip trip) {
-        CountedStopTime lastCountedStopTime = trip.getCountedStopTimes().get(trip.getCountedStopTimes().size() - 1);
-
-        PassengerCountingEvent lastPassengerCountingEvent = null;
-        if (!lastCountedStopTime.getPassengerCountingEvents().isEmpty()) {
-            lastPassengerCountingEvent = lastCountedStopTime.getPassengerCountingEvents().get(lastCountedStopTime.getPassengerCountingEvents().size() - 1);
-        }
-
-        return lastPassengerCountingEvent;
     }
 }

--- a/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsViewModel.java
+++ b/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsViewModel.java
@@ -24,11 +24,16 @@ import de.vdvcount.app.model.Trip;
 import de.vdvcount.app.model.WayPoint;
 import de.vdvcount.app.remote.RemoteRepository;
 import de.vdvcount.app.ui.counting.CountingFragment;
+import de.vdvcount.app.ui.tripclosing.TripClosingFragment;
 
 public class TripDetailsViewModel extends ViewModel {
 
     private MutableLiveData<TripDetailsFragment.State> state;
     private MutableLiveData<CountedTrip> countedTrip;
+
+    // hold a code for the last tried action
+    // this is used in the method retryLastAction()
+    private int lastActionCode = 0;
 
     public TripDetailsViewModel() {
         this.state = new MutableLiveData<>(TripDetailsFragment.State.READY);
@@ -45,53 +50,17 @@ public class TripDetailsViewModel extends ViewModel {
 
     public void startCountedTrip(int tripId, String vehicleId, int vehicleNumDoors, int startStopSequence) {
         Runnable runnable = () -> {
-            this.state.postValue(TripDetailsFragment.State.LOADING);
+            this.internalStartCountedTrip(tripId, vehicleId, vehicleNumDoors, startStopSequence);
+        };
 
-            RemoteRepository remoteRepository = RemoteRepository.getInstance();
-            Trip trip = remoteRepository.getTripByTripId(tripId);
+        Thread thread = new Thread(runnable);
+        thread.start();
+    }
 
-            if (trip != null) {
-                FilesystemRepository filesystemRepository = FilesystemRepository.getInstance();
-                CountedTrip countedTrip = filesystemRepository.startCountedTrip(trip, vehicleId, vehicleNumDoors);
-
-                if (Status.getBoolean(Status.STAY_IN_VEHICLE, false)) {
-                    String passengerCountingEventJson = Status.getString(Status.LAST_PCE, null);
-                    if (passengerCountingEventJson != null) {
-                        PassengerCountingEvent passengerCountingEvent = PassengerCountingEvent.deserialize(passengerCountingEventJson);
-                        for (CountingSequence cs : passengerCountingEvent.getCountingSequences()) {
-                            cs.setOut(0);
-
-                            // see #57, PCEs with stayInVehicle flag should be re-started at the half of their duration + 1s
-                            // this is done on CS level, because start and end timestamps are stored for each CS
-                            Date startTimestamp = cs.getCountBeginTimestamp();
-                            Date endTimestamp = cs.getCountEndTimestamp();
-
-                            long midpoint = (startTimestamp.getTime() + endTimestamp.getTime()) / 2;
-                            Date updatedStartDate = new Date(midpoint + 1000);
-                            cs.setCountBeginTimestamp(updatedStartDate);
-                        }
-
-                        countedTrip.getCountedStopTimes().get(0).getPassengerCountingEvents().add(passengerCountingEvent);
-                        filesystemRepository.updateCountedTrip(countedTrip);
-                    }
-
-                    Status.setBoolean(Status.STAY_IN_VEHICLE, false);
-                    Status.setString(Status.LAST_PCE, null);
-                    Status.setString(Status.LAST_VEHICLE_ID, null);
-                    Status.setStringArray(Status.LAST_COUNTED_DOOR_IDS, new String[] {});
-                }
-
-                this.countedTrip.postValue(countedTrip);
-                this.state.postValue(TripDetailsFragment.State.READY);
-
-                Status.setString(Status.STATUS, Status.Values.COUNTING);
-                Status.setInt(Status.CURRENT_TRIP_ID, tripId);
-                Status.setInt(Status.CURRENT_START_STOP_SEQUENCE, startStopSequence);
-                Status.setString(Status.CURRENT_VEHICLE_ID, vehicleId);
-                Status.setInt(Status.CURRENT_VEHICLE_NUM_DOORS, vehicleNumDoors);
-            } else {
-                this.state.postValue(TripDetailsFragment.State.ERROR);
-            }
+    public void loadCountedTrip() {
+        Runnable runnable = () -> {
+            FilesystemRepository repository = FilesystemRepository.getInstance();
+            this.countedTrip.postValue(repository.loadCountedTrip());
         };
 
         Thread thread = new Thread(runnable);
@@ -107,6 +76,82 @@ public class TripDetailsViewModel extends ViewModel {
             Status.setInt(Status.CURRENT_TRIP_ID, -1);
             Status.setInt(Status.CURRENT_START_STOP_SEQUENCE, -1);
             Status.setString(Status.CURRENT_VEHICLE_ID, "");
+        };
+
+        Thread thread = new Thread(runnable);
+        thread.start();
+    }
+
+    public void closeCountedTripAndLoadNextTrip() {
+        Runnable runnable = () -> {
+            // check whether we have a counted trip at all and the counted trip has a next trip ID set
+            if (this.countedTrip.getValue() == null || this.countedTrip.getValue().getNextTripId() == 0) {
+                return;
+            }
+
+            this.state.postValue(TripDetailsFragment.State.LOADING);
+
+            // keep track of the last action we are trying to perform...
+            this.lastActionCode = 1;
+
+            // load all required status variables
+            String vehicleId = Status.getString(Status.CURRENT_VEHICLE_ID, null);
+            int vehicleNumDoors = Status.getInt(Status.CURRENT_VEHICLE_NUM_DOORS, -1);
+            String[] countedDoorIds = Status.getStringArray(Status.CURRENT_COUNTED_DOOR_IDS, new String[] {});
+
+            // 1st step: close counted trip object by modifying the last PCE object
+            // see comments below for documentation
+            FilesystemRepository filesystemRepository = FilesystemRepository.getInstance();
+            CountedTrip lastCountedTrip = filesystemRepository.loadCountedTrip();
+
+            // extract last PCE and modify it to show up as connected PCE
+            // keep a copy of the PCE in order to modify it a second time when generating the new trip
+            PassengerCountingEvent lastPassengerCountingEvent = lastCountedTrip.getLastPce();
+            Status.setString(Status.LAST_PCE, lastPassengerCountingEvent != null ? lastPassengerCountingEvent.serialize() : null);
+
+            if (lastPassengerCountingEvent != null) {
+                for (CountingSequence cs : lastPassengerCountingEvent.getCountingSequences()) {
+                    cs.setIn(0);
+
+                    // see #57, PCEs with stayInVehicle flag should be cut-off at the half of their duration
+                    // this is done on CS level, because start and end timestamps are stored for each CS
+                    Date startTimestamp = cs.getCountBeginTimestamp();
+                    Date endTimestamp = cs.getCountEndTimestamp();
+
+                    long midpoint = (startTimestamp.getTime() + endTimestamp.getTime()) / 2;
+                    Date updatedEndDate = new Date(midpoint);
+                    cs.setCountEndTimestamp(updatedEndDate);
+                }
+            }
+
+            // finally post the current trip object to the server
+            RemoteRepository remoteRepository = RemoteRepository.getInstance();
+            if (remoteRepository.postResults(lastCountedTrip)) {
+                filesystemRepository.closeCountedTrip();
+
+                // update status variables
+                // set CURRENT_TRIP_ID in order to keep track of which
+                // SHOULD be the next trip. In case of a retry, this variable is loaded again
+                // in retryLastAction() and is responsible for loading the correct next trip
+                Status.setInt(Status.CURRENT_TRIP_ID, lastCountedTrip.getNextTripId());
+
+                Status.setString(Status.LAST_VEHICLE_ID, vehicleId);
+                Status.setStringArray(Status.LAST_COUNTED_DOOR_IDS, countedDoorIds);
+                Status.setBoolean(Status.STAY_IN_VEHICLE, true);
+
+                // performing next action now...
+                this.lastActionCode = 0;
+
+                // load next trip here ...
+                this.internalStartCountedTrip(
+                        lastCountedTrip.getNextTripId(),
+                        vehicleId,
+                        vehicleNumDoors,
+                        0
+                );
+            } else {
+                this.state.postValue(TripDetailsFragment.State.ERROR);
+            }
         };
 
         Thread thread = new Thread(runnable);
@@ -154,16 +199,6 @@ public class TripDetailsViewModel extends ViewModel {
         thread.start();
     }
 
-    public void loadCountedTrip() {
-        Runnable runnable = () -> {
-            FilesystemRepository repository = FilesystemRepository.getInstance();
-            this.countedTrip.postValue(repository.loadCountedTrip());
-        };
-
-        Thread thread = new Thread(runnable);
-        thread.start();
-    }
-
     public void addWayPoint(Location location) {
         final WayPoint wayPoint = new WayPoint();
         wayPoint.setLatitude(location.getLatitude());
@@ -184,5 +219,70 @@ public class TripDetailsViewModel extends ViewModel {
 
         Thread thread = new Thread(runnable);
         thread.start();
+    }
+
+    public void retryLastAction()
+    {
+        if (this.lastActionCode == 0) {
+            this.startCountedTrip(
+                    Status.getInt(Status.CURRENT_TRIP_ID, -1),
+                    Status.getString(Status.CURRENT_VEHICLE_ID, ""),
+                    Status.getInt(Status.CURRENT_VEHICLE_NUM_DOORS, -1),
+                    Status.getInt(Status.CURRENT_START_STOP_SEQUENCE, -1)
+            );
+        }
+        else if (this.lastActionCode == 1) {
+            this.closeCountedTripAndLoadNextTrip();
+        }
+    }
+
+    private void internalStartCountedTrip(int tripId, String vehicleId, int vehicleNumDoors, int startStopSequence) {
+        this.state.postValue(TripDetailsFragment.State.LOADING);
+
+        RemoteRepository remoteRepository = RemoteRepository.getInstance();
+        Trip trip = remoteRepository.getTripByTripId(tripId);
+
+        if (trip != null) {
+            FilesystemRepository filesystemRepository = FilesystemRepository.getInstance();
+            CountedTrip countedTrip = filesystemRepository.startCountedTrip(trip, vehicleId, vehicleNumDoors);
+
+            if (Status.getBoolean(Status.STAY_IN_VEHICLE, false)) {
+                String passengerCountingEventJson = Status.getString(Status.LAST_PCE, null);
+                if (passengerCountingEventJson != null) {
+                    PassengerCountingEvent passengerCountingEvent = PassengerCountingEvent.deserialize(passengerCountingEventJson);
+                    for (CountingSequence cs : passengerCountingEvent.getCountingSequences()) {
+                        cs.setOut(0);
+
+                        // see #57, PCEs with stayInVehicle flag should be re-started at the half of their duration + 1s
+                        // this is done on CS level, because start and end timestamps are stored for each CS
+                        Date startTimestamp = cs.getCountBeginTimestamp();
+                        Date endTimestamp = cs.getCountEndTimestamp();
+
+                        long midpoint = (startTimestamp.getTime() + endTimestamp.getTime()) / 2;
+                        Date updatedStartDate = new Date(midpoint + 1000);
+                        cs.setCountBeginTimestamp(updatedStartDate);
+                    }
+
+                    countedTrip.getCountedStopTimes().get(0).getPassengerCountingEvents().add(passengerCountingEvent);
+                    filesystemRepository.updateCountedTrip(countedTrip);
+                }
+
+                Status.setBoolean(Status.STAY_IN_VEHICLE, false);
+                Status.setString(Status.LAST_PCE, null);
+                Status.setString(Status.LAST_VEHICLE_ID, null);
+                Status.setStringArray(Status.LAST_COUNTED_DOOR_IDS, new String[] {});
+            }
+
+            this.countedTrip.postValue(countedTrip);
+            this.state.postValue(TripDetailsFragment.State.READY);
+
+            Status.setString(Status.STATUS, Status.Values.COUNTING);
+            Status.setInt(Status.CURRENT_TRIP_ID, tripId);
+            Status.setInt(Status.CURRENT_START_STOP_SEQUENCE, startStopSequence);
+            Status.setString(Status.CURRENT_VEHICLE_ID, vehicleId);
+            Status.setInt(Status.CURRENT_VEHICLE_NUM_DOORS, vehicleNumDoors);
+        } else {
+            this.state.postValue(TripDetailsFragment.State.ERROR);
+        }
     }
 }

--- a/app/src/main/res/layout/fragment_trip_details.xml
+++ b/app/src/main/res/layout/fragment_trip_details.xml
@@ -46,34 +46,46 @@
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"  />
 
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/btnCancel"
+                    <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/app_large_spacing"
-                        android:layout_marginStart="@dimen/app_default_spacing"
-                        android:layout_marginEnd="@dimen/app_default_spacing"
-                        android:layout_marginBottom="8dp"
-                        android:text="@string/trip_details_cancel"
-                        app:backgroundTint="@color/color_danger"
+                        android:orientation="vertical"
                         app:layout_constraintTop_toBottomOf="@id/lstCountedStopTimes"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintBottom_toTopOf="@id/btnQuit" />
+                        app:layout_constraintBottom_toBottomOf="parent">
 
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/btnQuit"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/app_default_spacing"
-                        android:layout_marginStart="@dimen/app_default_spacing"
-                        android:layout_marginEnd="@dimen/app_default_spacing"
-                        android:layout_marginBottom="8dp"
-                        android:text="@string/trip_details_quit"
-                        app:layout_constraintTop_toBottomOf="@id/btnCancel"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintBottom_toBottomOf="parent" />
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnNextTrip"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/app_default_spacing"
+                            android:layout_marginEnd="@dimen/app_default_spacing"
+                            android:layout_marginBottom="8dp"
+                            android:text="@string/trip_details_next_trip" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnQuit"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/app_default_spacing"
+                            android:layout_marginEnd="@dimen/app_default_spacing"
+                            android:layout_marginBottom="8dp"
+                            android:text="@string/trip_details_quit" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnCancel"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/app_large_spacing"
+                            android:layout_marginStart="@dimen/app_default_spacing"
+                            android:layout_marginEnd="@dimen/app_default_spacing"
+                            android:layout_marginBottom="8dp"
+                            android:text="@string/trip_details_cancel"
+                            app:backgroundTint="@color/color_danger"/>
+
+                    </LinearLayout>
 
                 </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,8 @@
     <string name="trip_details_cancel">Fahrt abbrechen</string>
     <string name="trip_details_cancel_confirmation">Fahrt wirklich abbrechen?</string>
     <string name="trip_details_quit">Fahrt abschließen</string>
+    <string name="trip_details_next_trip">Zur Folgefahrt wechseln</string>
+    <string name="trip_details_next_trip_confirmation">Wirklich zur Folgefahrt wechseln?</string>
 
     <!-- TripClosingFragment -->
     <string name="trip_closing_title">Fahrtabschluss</string>


### PR DESCRIPTION
Wenn über die API eine `next_trip_id` geliefert wird, wird in der Fahrtansicht im unteren Bereich ein Button "Zur Folgefahrt wechseln" angezeigt. Über diesen Button besteht die Möglichkeit, direkt auf die angegebene Folgefahrt zu wechseln. Dabei werden alle Durchbindungsregeln angewandt und Fahrzeug- bzw. Türdaten entsprechend mit übernommen. 

Außerdem wurden die Buttons im Fußbereich rearrangiert und an die tatsächliche Bedienung angepasst.