### PR TITLE
BugFix: Fehlerbehandlung bei Speicherfehlern

### DIFF
--- a/app/src/main/java/de/vdvcount/app/filesystem/FilesystemRepository.java
+++ b/app/src/main/java/de/vdvcount/app/filesystem/FilesystemRepository.java
@@ -58,30 +58,35 @@ public class FilesystemRepository {
     public void updateCountedTrip(CountedTrip countedTrip) {
         String countedTripFilename = this.getCountedTripFilename();
 
-        Gson gson = new GsonBuilder().serializeNulls().create();
-        String countedTripData = gson.toJson(countedTrip.mapApiObject());
-
-        FileOutputStream fos = null;
-
         try {
-            File outputFile = new File(countedTripFilename);
-            outputFile.createNewFile();
+            Gson gson = new GsonBuilder().serializeNulls().create();
+            String countedTripData = gson.toJson(countedTrip.mapApiObject());
 
-            fos = new FileOutputStream(countedTripFilename);
-
-            PrintStream printStream = new PrintStream(fos);
-            printStream.print(countedTripData);
-
-            Logging.i(this.getClass().getName(), "Updated CountedTrip object in local storage");
-        } catch (IOException e) {
-            Logging.e(this.getClass().getName(), "Failed to update CountedTrip object in local storage", e);
-        } finally {
+            FileOutputStream fos = null;
             try {
-                if (fos != null) {
-                    fos.close();
-                }
+                File outputFile = new File(countedTripFilename);
+                outputFile.createNewFile();
+
+                fos = new FileOutputStream(countedTripFilename);
+
+                PrintStream printStream = new PrintStream(fos);
+                printStream.print(countedTripData);
+
+                Logging.i(this.getClass().getName(), "Updated CountedTrip object in local storage");
             } catch (IOException e) {
+                Logging.e(this.getClass().getName(), "Failed to update CountedTrip object in local storage", e);
+            } finally {
+                try {
+                    if (fos != null) {
+                        fos.close();
+                    }
+                } catch (IOException e) {
+                }
             }
+        } catch (Exception e) {
+            Logging.e(this.getClass().getName(), "Failed to serialize CountedTrip object from local storage file", e);
+
+            throw new RuntimeException(e);
         }
     }
 
@@ -112,14 +117,20 @@ public class FilesystemRepository {
             }
         }
 
-        String countedTripObjectJson = new String(buffer, Charsets.UTF_8);
-        Gson gson = new GsonBuilder().serializeNulls().create();
+        try {
+            String countedTripObjectJson = new String(buffer, Charsets.UTF_8);
+            Gson gson = new GsonBuilder().serializeNulls().create();
 
-        CountedTripObject countedTripObject = gson.fromJson(countedTripObjectJson, CountedTripObject.class);
+            CountedTripObject countedTripObject = gson.fromJson(countedTripObjectJson, CountedTripObject.class);
 
-        Logging.i(this.getClass().getName(), "Loaded CountedTrip object from local storage");
+            Logging.i(this.getClass().getName(), "Loaded CountedTrip object from local storage");
 
-        return countedTripObject.mapDomainModel();
+            return countedTripObject.mapDomainModel();
+        } catch (Exception e) {
+            Logging.e(this.getClass().getName(), "Failed to deserialize CountedTrip object from local storage file", e);
+
+            throw new RuntimeException(e);
+        }
     }
 
     public void closeCountedTrip() {

--- a/app/src/main/java/de/vdvcount/app/ui/counting/CountingFragment.java
+++ b/app/src/main/java/de/vdvcount/app/ui/counting/CountingFragment.java
@@ -160,6 +160,15 @@ public class CountingFragment extends Fragment {
                 }
             });
         });
+
+        this.dataBinding.btnCloseSystemError.setOnClickListener(view -> {
+            Logging.i(this.getClass().getName(), "System error committed - Recreating valid app state");
+            Logging.i(this.getClass().getName(), "Cancelling current trip ...");
+            this.viewModel.cancelCountedTrip();
+
+            CountingFragmentDirections.ActionCountingFragmentToDepartureFragment action = CountingFragmentDirections.actionCountingFragmentToDepartureFragment();
+            this.navigationController.navigate(action);
+        });
     }
 
     private void initObserverEvents() {
@@ -207,7 +216,8 @@ public class CountingFragment extends Fragment {
     public enum State {
         INITIAL,
         STORING,
-        STORED
+        STORED,
+        SYSTEM_ERROR
     }
 
 }

--- a/app/src/main/java/de/vdvcount/app/ui/counting/CountingViewModel.java
+++ b/app/src/main/java/de/vdvcount/app/ui/counting/CountingViewModel.java
@@ -13,6 +13,7 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import de.vdvcount.app.common.LocationService;
 import de.vdvcount.app.common.Logging;
+import de.vdvcount.app.common.Status;
 import de.vdvcount.app.filesystem.FilesystemRepository;
 import de.vdvcount.app.model.CountedTrip;
 import de.vdvcount.app.model.CountingSequence;
@@ -59,6 +60,21 @@ public class CountingViewModel extends ViewModel {
         this.addPassengerCountingEventInternal(afterStopSequence, countingSequences, true);
     }
 
+    public void cancelCountedTrip() {
+        Runnable runnable = () -> {
+            FilesystemRepository filesystemRepository = FilesystemRepository.getInstance();
+            filesystemRepository.cancelCountedTrip();
+
+            Status.setString(Status.STATUS, Status.Values.READY);
+            Status.setInt(Status.CURRENT_TRIP_ID, -1);
+            Status.setInt(Status.CURRENT_START_STOP_SEQUENCE, -1);
+            Status.setString(Status.CURRENT_VEHICLE_ID, "");
+        };
+
+        Thread thread = new Thread(runnable);
+        thread.start();
+    }
+
     private void addPassengerCountingEventInternal(final int sequence, List<CountingSequence> countingSequences, boolean unmatched) {
         Runnable runnable = () -> {
             this.state.postValue(CountingFragment.State.STORING);
@@ -71,30 +87,41 @@ public class CountingViewModel extends ViewModel {
             }
 
             FilesystemRepository repository = FilesystemRepository.getInstance();
-            CountedTrip countedTrip = repository.loadCountedTrip();
+            CountedTrip countedTrip = null;
 
-            Location location = LocationService.getInstance().requestCurrentLocation();
-
-            PassengerCountingEvent pce = new PassengerCountingEvent();
-            pce.setCountingSequences(countingSequences);
-
-            if (location != null) {
-                pce.setLatitude(location.getLatitude());
-                pce.setLongitude(location.getLongitude());
-            } else {
-                Logging.w(this.getClass().getName(), "Location object is null, no location assigned with this PCE");
+            try {
+                countedTrip = repository.loadCountedTrip();
+            } catch (RuntimeException e) {
+                this.state.postValue(CountingFragment.State.SYSTEM_ERROR);
+                return;
             }
 
-            if (unmatched) {
-                pce.setAfterStopSequence(sequence);
-                countedTrip.getUnmatchedPassengerCountingEvents().add(pce);
+            if (countedTrip != null) {
+                Location location = LocationService.getInstance().requestCurrentLocation();
+
+                PassengerCountingEvent pce = new PassengerCountingEvent();
+                pce.setCountingSequences(countingSequences);
+
+                if (location != null) {
+                    pce.setLatitude(location.getLatitude());
+                    pce.setLongitude(location.getLongitude());
+                } else {
+                    Logging.w(this.getClass().getName(), "Location object is null, no location assigned with this PCE");
+                }
+
+                if (unmatched) {
+                    pce.setAfterStopSequence(sequence);
+                    countedTrip.getUnmatchedPassengerCountingEvents().add(pce);
+                } else {
+                    countedTrip.getCountedStopTimes().get(sequence - 1).getPassengerCountingEvents().add(pce);
+                }
+
+                repository.updateCountedTrip(countedTrip);
+
+                this.state.postValue(CountingFragment.State.STORED);
             } else {
-                countedTrip.getCountedStopTimes().get(sequence - 1).getPassengerCountingEvents().add(pce);
+                this.state.postValue(CountingFragment.State.INITIAL);
             }
-
-            repository.updateCountedTrip(countedTrip);
-
-            this.state.postValue(CountingFragment.State.STORED);
         };
 
         Thread thread = new Thread(runnable);

--- a/app/src/main/java/de/vdvcount/app/ui/tripclosing/TripClosingFragment.java
+++ b/app/src/main/java/de/vdvcount/app/ui/tripclosing/TripClosingFragment.java
@@ -24,6 +24,7 @@ import de.vdvcount.app.R;
 import de.vdvcount.app.common.LocationService;
 import de.vdvcount.app.common.Logging;
 import de.vdvcount.app.databinding.FragmentTripClosingBinding;
+import de.vdvcount.app.ui.tripdetails.TripDetailsFragmentDirections;
 
 public class TripClosingFragment extends Fragment {
 
@@ -129,7 +130,7 @@ public class TripClosingFragment extends Fragment {
             );
         });
 
-        this.dataBinding.btnRetry.setOnClickListener(view -> {
+        this.dataBinding.btnCloseError.setOnClickListener(view -> {
             Logging.i(this.getClass().getName(), "Retry requested - Trying to close CountedTrip again");
 
             this.closeTripRequested = true;
@@ -137,6 +138,18 @@ public class TripClosingFragment extends Fragment {
             this.viewModel.closeCountedTrip(
                     this.dataBinding.cbxStayInVehicle.isChecked()
             );
+        });
+
+        this.dataBinding.btnCloseSystemError.setOnClickListener(view -> {
+            Logging.i(this.getClass().getName(), "System error committed - Recreating valid app state");
+            Logging.i(this.getClass().getName(), "Cancelling current trip ...");
+            this.viewModel.cancelCountedTrip();
+
+            TripClosingFragmentDirections.ActionTripClosingFragmentToDepartureFragment action = TripClosingFragmentDirections.actionTripClosingFragmentToDepartureFragment();
+            action.setStationId(lastStationId);
+            action.setStationName(lastStationName);
+
+            this.navigationController.navigate(action);
         });
     }
 
@@ -181,6 +194,7 @@ public class TripClosingFragment extends Fragment {
         READY,
         LOADING,
         ERROR,
+        SYSTEM_ERROR,
         DONE
     }
 }

--- a/app/src/main/java/de/vdvcount/app/ui/tripclosing/TripClosingViewModel.java
+++ b/app/src/main/java/de/vdvcount/app/ui/tripclosing/TripClosingViewModel.java
@@ -31,7 +31,14 @@ public class TripClosingViewModel extends ViewModel {
             this.state.postValue(TripClosingFragment.State.LOADING);
 
             FilesystemRepository filesystemRepository = FilesystemRepository.getInstance();
-            CountedTrip countedTrip = filesystemRepository.loadCountedTrip();
+            CountedTrip countedTrip = null;
+
+            try {
+                countedTrip = filesystemRepository.loadCountedTrip();
+            } catch (RuntimeException e) {
+                this.state.postValue(TripClosingFragment.State.SYSTEM_ERROR);
+                return;
+            }
 
             if (stayInVehicle) {
                 PassengerCountingEvent passengerCountingEvent = countedTrip.getLastPce();
@@ -75,6 +82,21 @@ public class TripClosingViewModel extends ViewModel {
             } else {
                 this.state.postValue(TripClosingFragment.State.ERROR);
             }
+        };
+
+        Thread thread = new Thread(runnable);
+        thread.start();
+    }
+
+    public void cancelCountedTrip() {
+        Runnable runnable = () -> {
+            FilesystemRepository filesystemRepository = FilesystemRepository.getInstance();
+            filesystemRepository.cancelCountedTrip();
+
+            Status.setString(Status.STATUS, Status.Values.READY);
+            Status.setInt(Status.CURRENT_TRIP_ID, -1);
+            Status.setInt(Status.CURRENT_START_STOP_SEQUENCE, -1);
+            Status.setString(Status.CURRENT_VEHICLE_ID, "");
         };
 
         Thread thread = new Thread(runnable);

--- a/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsFragment.java
+++ b/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsFragment.java
@@ -1,14 +1,9 @@
 package de.vdvcount.app.ui.tripdetails;
 
-import androidx.core.content.ContextCompat;
 import androidx.databinding.DataBindingUtil;
 import androidx.lifecycle.ViewModelProvider;
 
-import android.content.BroadcastReceiver;
 import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
-import android.location.LocationManager;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -210,12 +205,20 @@ public class TripDetailsFragment extends Fragment {
             this.navigationController.navigate(action);
         });
 
-        this.dataBinding.btnRetry.setOnClickListener(view -> {
-            if (Status.getString(Status.STATUS, Status.Values.READY).equals(Status.Values.READY)
-                            || Status.getString(Status.STATUS, Status.Values.READY).equals(Status.Values.COUNTING)) {
+        this.dataBinding.btnCloseError.setOnClickListener(view -> {
+            if (Status.getString(Status.STATUS, Status.Values.READY).equals(Status.Values.READY) || Status.getString(Status.STATUS, Status.Values.READY).equals(Status.Values.COUNTING)) {
                 Logging.i(this.getClass().getName(), "Retry requested - Trying to perform last action again");
                 this.viewModel.retryLastAction();
             }
+        });
+
+        this.dataBinding.btnCloseSystemError.setOnClickListener(view -> {
+            Logging.i(this.getClass().getName(), "System error committed - Recreating valid app state");
+            Logging.i(this.getClass().getName(), "Cancelling current trip ...");
+            this.viewModel.cancelCountedTrip();
+
+            TripDetailsFragmentDirections.ActionTripDetailsFragmentToDepartureFragment action = TripDetailsFragmentDirections.actionTripDetailsFragmentToDepartureFragment();
+            this.navigationController.navigate(action);
         });
 
         this.dataBinding.scrollView.getViewTreeObserver().addOnGlobalLayoutListener(() -> {
@@ -369,6 +372,7 @@ public class TripDetailsFragment extends Fragment {
     public enum State {
         READY,
         LOADING,
-        ERROR
+        ERROR,
+        SYSTEM_ERROR
     }
 }

--- a/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsViewModel.java
+++ b/app/src/main/java/de/vdvcount/app/ui/tripdetails/TripDetailsViewModel.java
@@ -6,12 +6,8 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 
 import de.vdvcount.app.common.LocationService;
 import de.vdvcount.app.common.Logging;
@@ -23,8 +19,6 @@ import de.vdvcount.app.model.PassengerCountingEvent;
 import de.vdvcount.app.model.Trip;
 import de.vdvcount.app.model.WayPoint;
 import de.vdvcount.app.remote.RemoteRepository;
-import de.vdvcount.app.ui.counting.CountingFragment;
-import de.vdvcount.app.ui.tripclosing.TripClosingFragment;
 
 public class TripDetailsViewModel extends ViewModel {
 
@@ -60,7 +54,12 @@ public class TripDetailsViewModel extends ViewModel {
     public void loadCountedTrip() {
         Runnable runnable = () -> {
             FilesystemRepository repository = FilesystemRepository.getInstance();
-            this.countedTrip.postValue(repository.loadCountedTrip());
+            try {
+                CountedTrip countedTrip = repository.loadCountedTrip();
+                this.countedTrip.postValue(countedTrip);
+            } catch (RuntimeException e) {
+                this.state.postValue(TripDetailsFragment.State.SYSTEM_ERROR);
+            }
         };
 
         Thread thread = new Thread(runnable);
@@ -102,7 +101,14 @@ public class TripDetailsViewModel extends ViewModel {
             // 1st step: close counted trip object by modifying the last PCE object
             // see comments below for documentation
             FilesystemRepository filesystemRepository = FilesystemRepository.getInstance();
-            CountedTrip lastCountedTrip = filesystemRepository.loadCountedTrip();
+            CountedTrip lastCountedTrip = null;
+
+            try {
+                lastCountedTrip = filesystemRepository.loadCountedTrip();
+            } catch (RuntimeException e) {
+                this.state.postValue(TripDetailsFragment.State.SYSTEM_ERROR);
+                return;
+            }
 
             // extract last PCE and modify it to show up as connected PCE
             // keep a copy of the PCE in order to modify it a second time when generating the new trip
@@ -165,7 +171,14 @@ public class TripDetailsViewModel extends ViewModel {
             this.state.postValue(TripDetailsFragment.State.LOADING);
 
             FilesystemRepository repository = FilesystemRepository.getInstance();
-            CountedTrip countedTrip = repository.loadCountedTrip();
+            CountedTrip countedTrip = null;
+
+            try {
+                countedTrip = repository.loadCountedTrip();
+            } catch (RuntimeException e) {
+                this.state.postValue(TripDetailsFragment.State.SYSTEM_ERROR);
+                return;
+            }
 
             Location location = LocationService.getInstance().requestCurrentLocation();
             Date timestamp = new Date();
@@ -207,7 +220,14 @@ public class TripDetailsViewModel extends ViewModel {
 
         Runnable runnable = () -> {
             FilesystemRepository repository = FilesystemRepository.getInstance();
-            CountedTrip countedTrip = repository.loadCountedTrip();
+            CountedTrip countedTrip = null;
+
+            try {
+                countedTrip = repository.loadCountedTrip();
+            } catch (RuntimeException e) {
+                this.state.postValue(TripDetailsFragment.State.SYSTEM_ERROR);
+                return;
+            }
 
             // the LocationService may be started before the initial request for the counted trip
             // is proceeded. This would result in a NullReferenceException ...
@@ -244,7 +264,14 @@ public class TripDetailsViewModel extends ViewModel {
 
         if (trip != null) {
             FilesystemRepository filesystemRepository = FilesystemRepository.getInstance();
-            CountedTrip countedTrip = filesystemRepository.startCountedTrip(trip, vehicleId, vehicleNumDoors);
+            CountedTrip countedTrip = null;
+
+            try {
+                countedTrip = filesystemRepository.startCountedTrip(trip, vehicleId, vehicleNumDoors);
+            } catch (RuntimeException e) {
+                this.state.postValue(TripDetailsFragment.State.SYSTEM_ERROR);
+                return;
+            }
 
             if (Status.getBoolean(Status.STAY_IN_VEHICLE, false)) {
                 String passengerCountingEventJson = Status.getString(Status.LAST_PCE, null);
@@ -282,7 +309,7 @@ public class TripDetailsViewModel extends ViewModel {
             Status.setString(Status.CURRENT_VEHICLE_ID, vehicleId);
             Status.setInt(Status.CURRENT_VEHICLE_NUM_DOORS, vehicleNumDoors);
         } else {
-            this.state.postValue(TripDetailsFragment.State.ERROR);
+            this.cancelCountedTrip();
         }
     }
 }

--- a/app/src/main/res/layout/fragment_counting.xml
+++ b/app/src/main/res/layout/fragment_counting.xml
@@ -17,120 +17,126 @@
 
     </data>
 
-    <androidx.core.widget.NestedScrollView
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <LinearLayout
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="@{viewModel.state == CountingFragment.State.INITIAL ? View.VISIBLE : View.GONE}">
+
+                    <LinearLayout
+                        android:id="@+id/layoutStopInfo"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="center_vertical"
+                        android:padding="@dimen/app_default_spacing"
+                        app:layout_constraintBottom_toTopOf="@id/lstCountingSequences"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <ImageView
+                            android:layout_width="24dp"
+                            android:layout_height="24dp"
+                            android:layout_margin="@dimen/app_default_spacing"
+                            android:src="@drawable/ic_stop"
+                            app:tint="?attr/defaultIconColor" />
+
+                        <TextView
+                            android:id="@+id/lblStopInfo"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_margin="@dimen/app_default_spacing"
+                            android:layout_weight="1"
+                            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                            tools:text="Zählung an der Haltestelle Pforzheim Emilienstraße"/>
+
+                    </LinearLayout>
+
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/lstCountingSequences"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintTop_toBottomOf="@id/layoutStopInfo"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"  />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/btnSave"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/app_medium_spacing"
+                        android:layout_marginStart="@dimen/app_default_spacing"
+                        android:layout_marginEnd="@dimen/app_default_spacing"
+                        android:layout_marginBottom="8dp"
+                        android:text="@string/counting_save"
+                        app:layout_constraintTop_toBottomOf="@id/lstCountingSequences"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintBottom_toBottomOf="parent" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+            </LinearLayout>
+
+        </androidx.core.widget.NestedScrollView>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="@dimen/app_default_spacing"
+            android:visibility="@{viewModel.state == CountingFragment.State.SYSTEM_ERROR ? View.VISIBLE : View.GONE}">
+
+            <TextView
+                android:id="@+id/lblSystemErrorMessage"
+                android:layout_width="320dp"
+                android:layout_height="wrap_content"
+                android:text="@string/str_system_error"
+                android:textAlignment="center"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                app:layout_constraintBottom_toTopOf="@id/btnCloseSystemError"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnCloseSystemError"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/str_close"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:backgroundTint="@color/color_danger"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:visibility="@{viewModel.state == CountingFragment.State.STORING ? View.VISIBLE : View.GONE}">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:visibility="@{viewModel.state == CountingFragment.State.INITIAL ? View.VISIBLE : View.GONE}">
+            <ProgressBar
+                android:layout_width="56dp"
+                android:layout_height="56dp"
+                android:layout_marginTop="160dp"
+                android:layout_centerInParent="true"
+                style="?android:attr/progressBarStyleLarge" />
 
-                <LinearLayout
-                    android:id="@+id/layoutStopInfo"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:gravity="center_vertical"
-                    android:padding="@dimen/app_default_spacing"
-                    app:layout_constraintBottom_toTopOf="@id/lstCountingSequences"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent">
+        </RelativeLayout>
 
-                    <ImageView
-                        android:layout_width="24dp"
-                        android:layout_height="24dp"
-                        android:layout_margin="@dimen/app_default_spacing"
-                        android:src="@drawable/ic_stop"
-                        app:tint="?attr/defaultIconColor" />
-
-                    <TextView
-                        android:id="@+id/lblStopInfo"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_margin="@dimen/app_default_spacing"
-                        android:layout_weight="1"
-                        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
-                        tools:text="Zählung an der Haltestelle Pforzheim Emilienstraße"/>
-
-                </LinearLayout>
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/lstCountingSequences"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:layout_constraintTop_toBottomOf="@id/layoutStopInfo"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"  />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/btnSave"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/app_medium_spacing"
-                    android:layout_marginStart="@dimen/app_default_spacing"
-                    android:layout_marginEnd="@dimen/app_default_spacing"
-                    android:layout_marginBottom="8dp"
-                    android:text="@string/counting_save"
-                    app:layout_constraintTop_toBottomOf="@id/lstCountingSequences"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:padding="@dimen/app_default_spacing"
-                android:visibility="@{viewModel.state == CountingFragment.State.SYSTEM_ERROR ? View.VISIBLE : View.GONE}">
-
-                <TextView
-                    android:id="@+id/lblSystemErrorMessage"
-                    android:layout_width="320dp"
-                    android:layout_height="wrap_content"
-                    android:text="@string/str_system_error"
-                    android:textAlignment="center"
-                    android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
-                    app:layout_constraintBottom_toTopOf="@id/btnCloseSystemError"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <com.google.android.material.button.MaterialButton
-                    android:id="@+id/btnCloseSystemError"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/str_close"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:backgroundTint="@color/color_danger"/>
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <RelativeLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:visibility="@{viewModel.state == CountingFragment.State.STORING ? View.VISIBLE : View.GONE}">
-
-                <ProgressBar
-                    android:layout_width="56dp"
-                    android:layout_height="56dp"
-                    android:layout_marginTop="160dp"
-                    android:layout_centerInParent="true"
-                    style="?android:attr/progressBarStyleLarge" />
-
-            </RelativeLayout>
-
-        </LinearLayout>
-
-    </androidx.core.widget.NestedScrollView>
+    </FrameLayout>
 
 </layout>

--- a/app/src/main/res/layout/fragment_counting.xml
+++ b/app/src/main/res/layout/fragment_counting.xml
@@ -85,6 +85,36 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="@dimen/app_default_spacing"
+                android:visibility="@{viewModel.state == CountingFragment.State.SYSTEM_ERROR ? View.VISIBLE : View.GONE}">
+
+                <TextView
+                    android:id="@+id/lblSystemErrorMessage"
+                    android:layout_width="320dp"
+                    android:layout_height="wrap_content"
+                    android:text="@string/str_system_error"
+                    android:textAlignment="center"
+                    android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                    app:layout_constraintBottom_toTopOf="@id/btnCloseSystemError"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnCloseSystemError"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/str_close"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:backgroundTint="@color/color_danger"/>
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
             <RelativeLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_trip_closing.xml
+++ b/app/src/main/res/layout/fragment_trip_closing.xml
@@ -124,7 +124,7 @@
                 android:id="@+id/btnCloseSystemError"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/str_retry"
+                android:text="@string/str_close"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_trip_closing.xml
+++ b/app/src/main/res/layout/fragment_trip_closing.xml
@@ -86,19 +86,49 @@
                 android:text="@string/str_network_load_error"
                 android:textAlignment="center"
                 android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
-                app:layout_constraintBottom_toTopOf="@id/btnRetry"
+                app:layout_constraintBottom_toTopOf="@id/btnCloseError"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/btnRetry"
+                android:id="@+id/btnCloseError"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/str_retry"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="@dimen/app_default_spacing"
+            android:visibility="@{viewModel.state == TripClosingFragment.State.SYSTEM_ERROR ? View.VISIBLE : View.GONE}">
+
+            <TextView
+                android:id="@+id/lblSystemErrorMessage"
+                android:layout_width="320dp"
+                android:layout_height="wrap_content"
+                android:text="@string/str_system_error"
+                android:textAlignment="center"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                app:layout_constraintBottom_toTopOf="@id/btnCloseSystemError"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnCloseSystemError"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/str_retry"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:backgroundTint="@color/color_danger"/>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_trip_details.xml
+++ b/app/src/main/res/layout/fragment_trip_details.xml
@@ -108,7 +108,7 @@
         </androidx.core.widget.NestedScrollView>
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/permission"
+            android:id="@+id/error"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:padding="@dimen/app_default_spacing"
@@ -122,19 +122,51 @@
                 android:text="@string/str_network_load_error"
                 android:textAlignment="center"
                 android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
-                app:layout_constraintBottom_toTopOf="@id/btnRetry"
+                app:layout_constraintBottom_toTopOf="@id/btnCloseError"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <com.google.android.material.button.MaterialButton
-                android:id="@+id/btnRetry"
+                android:id="@+id/btnCloseError"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/str_retry"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/systemError"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="@dimen/app_default_spacing"
+            android:visibility="@{viewModel.state == TripDetailsFragment.State.SYSTEM_ERROR ? View.VISIBLE : View.GONE}"
+            tools:context=".ui.tripdetails.TripDetailsFragment">
+
+            <TextView
+                android:id="@+id/lblSystemErrorMessage"
+                android:layout_width="320dp"
+                android:layout_height="wrap_content"
+                android:text="@string/str_system_error"
+                android:textAlignment="center"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                app:layout_constraintBottom_toTopOf="@id/btnCloseSystemError"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnCloseSystemError"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/str_close"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:backgroundTint="@color/color_danger"/>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/navigation/navigation_graph.xml
+++ b/app/src/main/res/navigation/navigation_graph.xml
@@ -194,6 +194,12 @@
         <argument
             android:name="countedDoorIds"
             app:argType="string[]" />
+        <action
+            android:id="@+id/action_countingFragment_to_departureFragment"
+            app:destination="@id/departureFragment"
+            app:launchSingleTop="true"
+            app:popUpTo="@id/navigation_graph.xml"
+            app:popUpToInclusive="true" />
     </fragment>
     <fragment
         android:id="@+id/tripClosingFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,8 +70,10 @@
     <string name="str_minus">-</string>
     <string name="str_plus">+</string>
     <string name="str_network_load_error">Während der Anfrage ist ein Fehler aufgetreten. Bitte prüfen Sie Ihre Netzwerkverbindung und versuchen Sie es erneut.</string>
+    <string name="str_system_error">Während der Aktion ist ein Systemfehler aufgetreten.</string>
     <string name="str_additional_stop">Zwischenhalt</string>
     <string name="str_run_through">Durchfahrt</string>
+    <string name="str_close">Schließen</string>
 
     <string name="str_format_time">HH:mm</string>
 </resources>


### PR DESCRIPTION
Die App wurde dahingehend angepasst, dass sie nun auch Speicherfehler beim lesen / schreiben der lokalen Datei zum Zwischenspeichern der Zählergebnisse korrekt behandelt. Zuvor hatte solch ein Fehler zu einem DeadLock geführt.